### PR TITLE
fix: repair a link and help text damaged by the brand sweep

### DIFF
--- a/cmd/find.go
+++ b/cmd/find.go
@@ -108,7 +108,7 @@ func patternMatch(pattern, match string) bool {
 // supports  '*' and '?' wildcards in the pattern string.
 // unlike path.Match(), considers a path as a flat name space
 // while matching the pattern. The difference is illustrated in
-// the example here https://mysilo.golang.org/p/Ega9qgD4Qz .
+// the example here https://play.golang.org/p/Ega9qgD4Qz .
 func pathMatch(pattern, path string) bool {
 	return wildcard.Match(pattern, path)
 }

--- a/cmd/support-proxy-set.go
+++ b/cmd/support-proxy-set.go
@@ -61,8 +61,8 @@ FLAGS:
 DESCRIPTION:
   This setting configures the outbound path a server uses to reach MinIO
   SUBNET. Since this Silo build disables SUBNET entirely, the command is
-  retained for CLI compatibility and always exits with an error. Use
-  '{{.HelpName}} ..' -> 'remove' to clear an existing proxy setting.
+  retained for CLI compatibility and always exits with an error. Run
+  'mc support proxy remove ALIAS' to clear an existing proxy setting.
 
 EXIT STATUS:
   1 - SUBNET services are disabled


### PR DESCRIPTION
Two minor defects found by an independent review of the 0804→HEAD range.

- `cmd/find.go:111` — the example-alias sweep replaced the bare word `play`, which also matched the Go playground link in the `pathMatch` comment, leaving a dead `https://mysilo.golang.org/p/Ega9qgD4Qz`. Restored. This was the only collateral hit; `git grep 'mysilo\.'` over `cmd/*.go` now returns nothing.
- `cmd/support-proxy-set.go` — the DESCRIPTION pointed at the sibling command as `'{{.HelpName}} ..' -> 'remove'`, which renders as noise. Now spells out `mc support proxy remove ALIAS`.

Verified: `go build ./...`, `go test ./cmd/ -count=1`, `check-branding.sh` pass; help output rendering checked on the built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)