### PR TITLE
feat: add read-only checksum verification

### DIFF
--- a/cmd/auto-complete.go
+++ b/cmd/auto-complete.go
@@ -230,6 +230,8 @@ var (
 // with their bash completer function
 var completeCmds = map[string]complete.Predictor{
 	// S3 API level commands
+	"/checksum/verify": s3Completer,
+
 	"/ls":        complete.PredictOr(s3Completer, fsCompleter),
 	"/cp":        complete.PredictOr(s3Completer, fsCompleter),
 	"/mv":        complete.PredictOr(s3Completer, fsCompleter),

--- a/cmd/checksum-main.go
+++ b/cmd/checksum-main.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2015-2025 MinIO, Inc.
+// Copyright (c) 2025-2026 PGSTY
+//
+// This file is part of MinIO Client
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import "github.com/minio/cli"
+
+var checksumSubcommands = []cli.Command{
+	checksumVerifyCmd,
+}
+
+var checksumCmd = cli.Command{
+	Name:            "checksum",
+	Usage:           "verify object checksums",
+	Action:          mainChecksum,
+	Before:          setGlobalsFromContext,
+	Flags:           globalFlags,
+	Subcommands:     checksumSubcommands,
+	HideHelpCommand: true,
+}
+
+func mainChecksum(ctx *cli.Context) error {
+	commandNotFound(ctx, checksumSubcommands)
+	return nil
+}

--- a/cmd/checksum-verify.go
+++ b/cmd/checksum-verify.go
@@ -801,8 +801,24 @@ func runChecksumVerifyWorkers(ctx context.Context, backend checksumVerifyBackend
 	return results
 }
 
+// checksumVerifyFlagEnabled checks every command level because GlobalBool stops
+// at the nearest ancestor flag set and cannot see an app-level flag here.
+func checksumVerifyFlagEnabled(cliCtx *cli.Context, name string) bool {
+	for ctx := cliCtx; ctx != nil; ctx = ctx.Parent() {
+		if ctx.Bool(name) {
+			return true
+		}
+	}
+	return false
+}
+
 func mainChecksumVerify(cliCtx *cli.Context) error {
 	validateChecksumVerifySyntax(cliCtx)
+	quiet := checksumVerifyFlagEnabled(cliCtx, "quiet")
+	if checksumVerifyFlagEnabled(cliCtx, "json") && !isTerminal() {
+		// A nested Before hook can reset this after an app-level --json.
+		globalJSONLine = true
+	}
 	ctx, cancel := context.WithCancel(globalContext)
 	defer cancel()
 
@@ -857,7 +873,7 @@ func mainChecksumVerify(cliCtx *cli.Context) error {
 				cancel()
 			}
 		}
-		if !globalQuiet {
+		if !quiet {
 			printMsg(result)
 		}
 	}
@@ -870,7 +886,7 @@ func mainChecksumVerify(cliCtx *cli.Context) error {
 	if outputErr == nil {
 		outputErr = report.write(summary)
 	}
-	if !globalQuiet {
+	if !quiet {
 		printMsg(summary)
 	}
 	if closeErr := report.close(); outputErr == nil {

--- a/cmd/checksum-verify.go
+++ b/cmd/checksum-verify.go
@@ -1,0 +1,891 @@
+// Copyright (c) 2015-2025 MinIO, Inc.
+// Copyright (c) 2025-2026 PGSTY
+//
+// This file is part of MinIO Client
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	stdjson "encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/minio/cli"
+	json "github.com/minio/colorjson"
+	"github.com/minio/mc/pkg/probe"
+	minio "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/encrypt"
+)
+
+const (
+	checksumVerifySchemaVersion = 1
+
+	checksumResultMatch                    = "MATCH"
+	checksumResultMismatch                 = "MISMATCH"
+	checksumResultNoChecksum               = "NO_CHECKSUM"
+	checksumResultWouldVerify              = "WOULD_VERIFY"
+	checksumResultSkippedDeleteMarker      = "SKIPPED_DELETE_MARKER"
+	checksumResultSkippedTimeFilter        = "SKIPPED_TIME_FILTER"
+	checksumResultSkippedTooLarge          = "SKIPPED_TOO_LARGE"
+	checksumResultUnknownComposite         = "UNKNOWN_UNSUPPORTED_COMPOSITE"
+	checksumResultUnknownChecksumType      = "UNKNOWN_CHECKSUM_TYPE"
+	checksumResultUnknownChecksumAlgorithm = "UNKNOWN_CHECKSUM_ALGORITHM"
+	checksumResultUnknownSSECKeyMissing    = "UNKNOWN_SSEC_KEY_MISSING"
+	checksumResultUnknownAccessDenied      = "UNKNOWN_ACCESS_DENIED"
+	checksumResultUnknownKMSError          = "UNKNOWN_KMS_ERROR"
+	checksumResultUnknownStorageClass      = "UNKNOWN_STORAGE_CLASS"
+	checksumResultUnknownObjectChanged     = "UNKNOWN_OBJECT_CHANGED"
+	checksumResultUnknownShortRead         = "UNKNOWN_SHORT_READ"
+	checksumResultUnknownReadError         = "UNKNOWN_READ_ERROR"
+	checksumVerifyFullObjectType           = "FULL_OBJECT"
+	checksumVerifyCompositeType            = "COMPOSITE"
+	checksumVerifyDefaultWorkers           = 4
+	checksumVerifyMaximumWorkers           = 64
+	checksumVerifyManifestMaximumLineSize  = 2 << 20
+)
+
+var checksumVerifyFlags = []cli.Flag{
+	cli.BoolFlag{
+		Name:  "recursive, r",
+		Usage: "verify all objects recursively under a bucket or prefix",
+	},
+	cli.BoolFlag{
+		Name:  "versions",
+		Usage: "verify all object versions",
+	},
+	cli.StringFlag{
+		Name:  "version-id, vid",
+		Usage: "verify a specific object version",
+	},
+	cli.StringFlag{
+		Name:  "older-than",
+		Usage: "verify objects older than value in duration string (e.g. 7d10h31s)",
+	},
+	cli.StringFlag{
+		Name:  "newer-than",
+		Usage: "verify objects newer than value in duration string (e.g. 7d10h31s)",
+	},
+	cli.IntFlag{
+		Name:  "max-workers",
+		Usage: "maximum number of concurrent object reads",
+		Value: checksumVerifyDefaultWorkers,
+	},
+	cli.BoolFlag{
+		Name:  "dry-run",
+		Usage: "list and stat candidates without reading object data",
+	},
+	cli.StringFlag{
+		Name:  "max-size",
+		Usage: "skip objects larger than this size (e.g. 10GiB)",
+	},
+	cli.StringFlag{
+		Name:  "manifest",
+		Usage: "verify bucket/key/versionId entries from a JSON Lines manifest",
+	},
+	cli.StringFlag{
+		Name:  "report",
+		Usage: "write object results and summary to a new JSON Lines file",
+	},
+	cli.StringFlag{
+		Name:  "fail-on",
+		Usage: "return failure on mismatch, unknown, any, or none",
+		Value: "any",
+	},
+}
+
+var checksumVerifyCmd = cli.Command{
+	Name:         "verify",
+	Usage:        "verify stored checksums against logical object data",
+	Action:       mainChecksumVerify,
+	OnUsageError: onUsageError,
+	Before:       setGlobalsFromContext,
+	Flags:        append(append(checksumVerifyFlags, encCFlag), globalFlags...),
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} [FLAGS] ALIAS/BUCKET/OBJECT
+  {{.HelpName}} --recursive [FLAGS] ALIAS/BUCKET[/PREFIX]
+  {{.HelpName}} --manifest FILE [FLAGS] ALIAS
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+
+EXAMPLES:
+  1. Verify one object checksum.
+     {{.Prompt}} {{.HelpName}} play/archive/report.json
+
+  2. Estimate the read cost before recursively verifying a prefix.
+     {{.Prompt}} {{.HelpName}} --recursive --dry-run play/archive/2025/
+
+  3. Verify all historical versions under a prefix with four workers.
+     {{.Prompt}} {{.HelpName}} --recursive --versions --max-workers 4 play/archive/2025/
+
+  4. Verify exact objects supplied by an external candidate manifest.
+     {{.Prompt}} {{.HelpName}} --manifest candidates.jsonl --report results.jsonl play
+`,
+}
+
+type checksumVerifyCandidate struct {
+	Alias        string
+	Bucket       string
+	Key          string
+	VersionID    string
+	DeleteMarker bool
+}
+
+type checksumVerifyManifestEntry struct {
+	Bucket    string `json:"bucket"`
+	Key       string `json:"key"`
+	VersionID string `json:"versionId,omitempty"`
+}
+
+type checksumVerifyResult struct {
+	SchemaVersion       int               `json:"schemaVersion"`
+	Type                string            `json:"type"`
+	Timestamp           time.Time         `json:"timestamp"`
+	Alias               string            `json:"alias"`
+	Bucket              string            `json:"bucket"`
+	Key                 string            `json:"key"`
+	VersionID           string            `json:"versionId,omitempty"`
+	Size                int64             `json:"size"`
+	ETag                string            `json:"etag,omitempty"`
+	LastModified        *time.Time        `json:"lastModified,omitempty"`
+	ChecksumType        string            `json:"checksumType,omitempty"`
+	StoredChecksums     map[string]string `json:"storedChecksums,omitempty"`
+	CalculatedChecksums map[string]string `json:"calculatedChecksums,omitempty"`
+	Result              string            `json:"result"`
+	ErrorCode           string            `json:"errorCode,omitempty"`
+	ErrorMessage        string            `json:"errorMessage,omitempty"`
+	BytesRead           int64             `json:"bytesRead"`
+}
+
+func (r checksumVerifyResult) String() string {
+	resource := r.Alias + "/" + r.Bucket + "/" + r.Key
+	if r.VersionID != "" {
+		resource += "?versionId=" + r.VersionID
+	}
+	if r.ErrorMessage != "" {
+		return fmt.Sprintf("%-38s %s (%s)", r.Result, resource, r.ErrorMessage)
+	}
+	return fmt.Sprintf("%-38s %s", r.Result, resource)
+}
+
+func (r checksumVerifyResult) JSON() string {
+	b, err := json.MarshalIndent(r, "", " ")
+	fatalIf(probe.NewError(err), "Unable to marshal checksum verification result.")
+	return string(b)
+}
+
+type checksumVerifySummary struct {
+	SchemaVersion int              `json:"schemaVersion"`
+	Type          string           `json:"type"`
+	Timestamp     time.Time        `json:"timestamp"`
+	Counts        map[string]int64 `json:"counts"`
+	Objects       int64            `json:"objects"`
+	BytesPlanned  int64            `json:"bytesPlanned"`
+	BytesRead     int64            `json:"bytesRead"`
+	Duration      time.Duration    `json:"durationNs"`
+	DryRun        bool             `json:"dryRun"`
+	Incomplete    bool             `json:"incomplete"`
+}
+
+func newChecksumVerifySummary(dryRun bool) checksumVerifySummary {
+	return checksumVerifySummary{
+		SchemaVersion: checksumVerifySchemaVersion,
+		Type:          "summary",
+		Timestamp:     UTCNow(),
+		Counts:        make(map[string]int64),
+		DryRun:        dryRun,
+	}
+}
+
+func (s *checksumVerifySummary) add(result checksumVerifyResult) {
+	s.Objects++
+	s.Counts[result.Result]++
+	s.BytesRead += result.BytesRead
+	switch result.Result {
+	case checksumResultWouldVerify:
+		s.BytesPlanned += result.Size
+	case checksumResultUnknownComposite,
+		checksumResultUnknownChecksumType,
+		checksumResultUnknownChecksumAlgorithm,
+		checksumResultUnknownSSECKeyMissing,
+		checksumResultUnknownAccessDenied,
+		checksumResultUnknownKMSError,
+		checksumResultUnknownStorageClass,
+		checksumResultUnknownObjectChanged,
+		checksumResultUnknownShortRead,
+		checksumResultUnknownReadError,
+		checksumResultSkippedTooLarge:
+		s.Incomplete = true
+	}
+}
+
+func (s checksumVerifySummary) String() string {
+	if s.DryRun {
+		return fmt.Sprintf("Checksum verification dry-run: %d objects, %d would verify, %d no-checksum, %d unknown, %d skipped, %s planned",
+			s.Objects,
+			s.Counts[checksumResultWouldVerify],
+			s.Counts[checksumResultNoChecksum],
+			s.unknownCount(),
+			s.skippedCount(),
+			humanize.IBytes(uint64(s.BytesPlanned)),
+		)
+	}
+	return fmt.Sprintf("Checksum verification: %d objects, %d match, %d mismatch, %d no-checksum, %d unknown, %d skipped, %s read",
+		s.Objects,
+		s.Counts[checksumResultMatch],
+		s.Counts[checksumResultMismatch],
+		s.Counts[checksumResultNoChecksum],
+		s.unknownCount(),
+		s.skippedCount(),
+		humanize.IBytes(uint64(s.BytesRead)),
+	)
+}
+
+func (s checksumVerifySummary) JSON() string {
+	b, err := json.MarshalIndent(s, "", " ")
+	fatalIf(probe.NewError(err), "Unable to marshal checksum verification summary.")
+	return string(b)
+}
+
+func (s checksumVerifySummary) unknownCount() int64 {
+	var n int64
+	for status, count := range s.Counts {
+		if strings.HasPrefix(status, "UNKNOWN_") {
+			n += count
+		}
+	}
+	return n
+}
+
+func (s checksumVerifySummary) skippedCount() int64 {
+	var n int64
+	for status, count := range s.Counts {
+		if strings.HasPrefix(status, "SKIPPED_") {
+			n += count
+		}
+	}
+	return n
+}
+
+func (s checksumVerifySummary) shouldFail(failOn string, dryRun bool) bool {
+	if dryRun {
+		return false
+	}
+	mismatch := s.Counts[checksumResultMismatch] > 0
+	unknown := s.unknownCount() > 0
+	incomplete := unknown || s.Counts[checksumResultSkippedTooLarge] > 0
+	switch failOn {
+	case "none":
+		return false
+	case "mismatch":
+		return mismatch
+	case "unknown":
+		return unknown
+	default:
+		return mismatch || incomplete
+	}
+}
+
+type checksumVerifyOptions struct {
+	DryRun      bool
+	MaximumSize int64
+	OlderThan   string
+	NewerThan   string
+	FailOn      string
+	Encryption  map[string][]prefixSSEPair
+}
+
+type checksumVerifyBackend interface {
+	statObjectForChecksumVerify(ctx context.Context, bucket, object, versionID string, sse encrypt.ServerSide) (checksumVerifyObjectInfo, error)
+	getObjectForChecksumVerify(ctx context.Context, bucket, object, versionID, ifMatchETag string, sse encrypt.ServerSide) (io.ReadCloser, error)
+}
+
+type checksumAlgorithm struct {
+	Name  string
+	Type  minio.ChecksumType
+	Value func(minio.ObjectInfo) string
+}
+
+var checksumVerifyAlgorithms = []checksumAlgorithm{
+	{Name: "CRC32", Type: minio.ChecksumCRC32, Value: func(info minio.ObjectInfo) string { return info.ChecksumCRC32 }},
+	{Name: "CRC32C", Type: minio.ChecksumCRC32C, Value: func(info minio.ObjectInfo) string { return info.ChecksumCRC32C }},
+	{Name: "CRC64NVME", Type: minio.ChecksumCRC64NVME, Value: func(info minio.ObjectInfo) string { return info.ChecksumCRC64NVME }},
+	{Name: "SHA1", Type: minio.ChecksumSHA1, Value: func(info minio.ObjectInfo) string { return info.ChecksumSHA1 }},
+	{Name: "SHA256", Type: minio.ChecksumSHA256, Value: func(info minio.ObjectInfo) string { return info.ChecksumSHA256 }},
+}
+
+type checksumVerifyReport struct {
+	file    *os.File
+	encoder *stdjson.Encoder
+}
+
+func openChecksumVerifyReport(path string) (*checksumVerifyReport, error) {
+	if path == "" {
+		return nil, nil
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err = file.Chmod(0o600); err != nil {
+		file.Close()
+		return nil, err
+	}
+	return &checksumVerifyReport{file: file, encoder: stdjson.NewEncoder(file)}, nil
+}
+
+func (r *checksumVerifyReport) write(v any) error {
+	if r == nil {
+		return nil
+	}
+	return r.encoder.Encode(v)
+}
+
+func (r *checksumVerifyReport) close() error {
+	if r == nil {
+		return nil
+	}
+	return r.file.Close()
+}
+
+func parseChecksumVerifyMaximumSize(value string) (int64, error) {
+	if value == "" {
+		return 0, nil
+	}
+	size, err := humanize.ParseBytes(value)
+	if err != nil {
+		return 0, err
+	}
+	if size > uint64(^uint64(0)>>1) {
+		return 0, fmt.Errorf("maximum size is too large")
+	}
+	return int64(size), nil
+}
+
+func validateChecksumVerifySelection(manifest, versionID string, versions, recursive bool, olderThan, newerThan string, workers int, failOn string) error {
+	if versionID != "" && (versions || recursive) {
+		return errors.New("--version-id cannot be combined with --versions or --recursive")
+	}
+	if manifest != "" && (versionID != "" || versions || recursive || olderThan != "" || newerThan != "") {
+		return errors.New("--manifest cannot be combined with object selection flags")
+	}
+	if workers < 1 || workers > checksumVerifyMaximumWorkers {
+		return fmt.Errorf("--max-workers must be between 1 and %d", checksumVerifyMaximumWorkers)
+	}
+	if failOn != "mismatch" && failOn != "unknown" && failOn != "any" && failOn != "none" {
+		return errors.New("--fail-on must be mismatch, unknown, any, or none")
+	}
+	return nil
+}
+
+func validateChecksumVerifySyntax(cliCtx *cli.Context) {
+	if len(cliCtx.Args()) != 1 || strings.TrimSpace(cliCtx.Args().First()) == "" {
+		showCommandHelpAndExit(cliCtx, 1)
+	}
+	manifest := cliCtx.String("manifest")
+	versionID := cliCtx.String("version-id")
+	versions := cliCtx.Bool("versions")
+	recursive := cliCtx.Bool("recursive")
+	olderThan := cliCtx.String("older-than")
+	newerThan := cliCtx.String("newer-than")
+
+	workers := cliCtx.Int("max-workers")
+	failOn := strings.ToLower(cliCtx.String("fail-on"))
+	selectionErr := validateChecksumVerifySelection(manifest, versionID, versions, recursive, olderThan, newerThan, workers, failOn)
+	fatalIf(probe.NewError(selectionErr), "Invalid checksum verification options.")
+	// Validate time filters once before workers call the existing skip helpers.
+	if olderThan != "" {
+		_ = isOlder(UTCNow(), olderThan)
+	}
+	if newerThan != "" {
+		_ = isNewer(UTCNow(), newerThan)
+	}
+	if manifest != "" && cliCtx.String("report") != "" {
+		manifestPath, err := filepath.Abs(manifest)
+		fatalIf(probe.NewError(err), "Unable to resolve checksum manifest path.")
+		reportPath, err := filepath.Abs(cliCtx.String("report"))
+		fatalIf(probe.NewError(err), "Unable to resolve checksum report path.")
+		if manifestPath == reportPath {
+			fatalIf(errInvalidArgument(), "--manifest and --report must refer to different files.")
+		}
+	}
+}
+
+func readChecksumVerifyManifest(ctx context.Context, path, alias string, out chan<- checksumVerifyCandidate) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), checksumVerifyManifestMaximumLineSize)
+	line := 0
+	for scanner.Scan() {
+		line++
+		value := strings.TrimSpace(scanner.Text())
+		if value == "" {
+			continue
+		}
+		var entry checksumVerifyManifestEntry
+		decoder := stdjson.NewDecoder(strings.NewReader(value))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&entry); err != nil {
+			return fmt.Errorf("manifest line %d: %w", line, err)
+		}
+		var extra any
+		if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+			if err == nil {
+				err = errors.New("multiple JSON values")
+			}
+			return fmt.Errorf("manifest line %d: %w", line, err)
+		}
+		if strings.TrimSpace(entry.Bucket) == "" || entry.Key == "" {
+			return fmt.Errorf("manifest line %d: bucket and key are required", line)
+		}
+		candidate := checksumVerifyCandidate{
+			Alias:     alias,
+			Bucket:    entry.Bucket,
+			Key:       entry.Key,
+			VersionID: entry.VersionID,
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case out <- candidate:
+		}
+	}
+	return scanner.Err()
+}
+
+func checksumVerifyBucketKey(content *ClientContent) (bucket, key string) {
+	path := strings.TrimPrefix(filepath.ToSlash(content.URL.Path), "/")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) == 0 {
+		return "", ""
+	}
+	bucket = parts[0]
+	if len(parts) == 2 {
+		key = parts[1]
+	}
+	return bucket, key
+}
+
+func scanChecksumVerifyCandidates(ctx context.Context, client *S3Client, target, alias, versionID string, recursive, versions bool, out chan<- checksumVerifyCandidate) error {
+	bucket, object := client.url2BucketAndObject()
+	if bucket == "" {
+		return errors.New("checksum verification requires an S3 bucket")
+	}
+	if versionID != "" {
+		if object == "" {
+			return errors.New("--version-id requires an object target")
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case out <- checksumVerifyCandidate{Alias: alias, Bucket: bucket, Key: object, VersionID: versionID}:
+			return nil
+		}
+	}
+
+	isPrefix := object == "" || strings.HasSuffix(target, "/") || recursive
+	if !versions && !isPrefix {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case out <- checksumVerifyCandidate{Alias: alias, Bucket: bucket, Key: object}:
+			return nil
+		}
+	}
+	if isPrefix && !recursive && object == "" {
+		return errors.New("bucket and prefix verification requires --recursive")
+	}
+	if strings.HasSuffix(target, "/") && !recursive {
+		return errors.New("prefix verification requires --recursive")
+	}
+
+	exactObject := versions && !recursive && object != "" && !strings.HasSuffix(target, "/")
+	listOptions := ListOptions{
+		Recursive:         true,
+		WithOlderVersions: versions,
+		WithDeleteMarkers: versions,
+		ShowDir:           DirNone,
+	}
+	for content := range client.List(ctx, listOptions) {
+		if content.Err != nil {
+			return content.Err.ToGoError()
+		}
+		listedBucket, key := checksumVerifyBucketKey(content)
+		if listedBucket == "" || key == "" || content.Type.IsDir() {
+			continue
+		}
+		if exactObject && key != object {
+			continue
+		}
+		candidate := checksumVerifyCandidate{
+			Alias:        alias,
+			Bucket:       listedBucket,
+			Key:          key,
+			VersionID:    content.VersionID,
+			DeleteMarker: content.IsDeleteMarker,
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case out <- candidate:
+		}
+	}
+	return nil
+}
+
+func checksumVerifyResultFor(candidate checksumVerifyCandidate) checksumVerifyResult {
+	return checksumVerifyResult{
+		SchemaVersion: checksumVerifySchemaVersion,
+		Type:          "object",
+		Timestamp:     UTCNow(),
+		Alias:         candidate.Alias,
+		Bucket:        candidate.Bucket,
+		Key:           candidate.Key,
+		VersionID:     candidate.VersionID,
+	}
+}
+
+func checksumVerifyErrorResult(candidate checksumVerifyCandidate, err error) checksumVerifyResult {
+	return applyChecksumVerifyError(checksumVerifyResultFor(candidate), err)
+}
+
+func applyChecksumVerifyError(result checksumVerifyResult, err error) checksumVerifyResult {
+	response := minio.ToErrorResponse(err)
+	result.ErrorCode = response.Code
+	result.ErrorMessage = err.Error()
+	code := strings.ToLower(response.Code)
+	message := strings.ToLower(response.Message)
+	switch {
+	case code == "invalidobjectstate":
+		result.Result = checksumResultUnknownStorageClass
+	case response.StatusCode == 403 || code == "accessdenied":
+		result.Result = checksumResultUnknownAccessDenied
+	case response.StatusCode == http.StatusPreconditionFailed || code == "preconditionfailed":
+		result.Result = checksumResultUnknownObjectChanged
+	case strings.Contains(code, "kms") || strings.Contains(message, "kms"):
+		result.Result = checksumResultUnknownKMSError
+	case strings.Contains(code, "sse") ||
+		strings.Contains(message, "server side encryption") ||
+		strings.Contains(message, "customer key") ||
+		strings.Contains(message, "sse-c"):
+		result.Result = checksumResultUnknownSSECKeyMissing
+	default:
+		result.Result = checksumResultUnknownReadError
+	}
+	return result
+}
+
+func mergeChecksumMaps(a, b map[string]string) map[string]string {
+	if len(a) == 0 && len(b) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(a)+len(b))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		out[k] = v
+	}
+	return out
+}
+
+func checksumVerifyHashers(stored map[string]string) (map[string]hash.Hash, []io.Writer) {
+	hashers := make(map[string]hash.Hash, len(stored))
+	writers := make([]io.Writer, 0, len(stored))
+	for _, algorithm := range checksumVerifyAlgorithms {
+		if stored[algorithm.Name] == "" {
+			continue
+		}
+		h := algorithm.Type.Hasher()
+		if h == nil {
+			continue
+		}
+		hashers[algorithm.Name] = h
+		writers = append(writers, h)
+	}
+	return hashers, writers
+}
+
+func checksumVerifyObjectChanged(before, after checksumVerifyObjectInfo) bool {
+	return before.ETag != after.ETag || before.Size != after.Size || !before.LastModified.Equal(after.LastModified)
+}
+
+func verifyChecksumCandidate(ctx context.Context, backend checksumVerifyBackend, candidate checksumVerifyCandidate, opts checksumVerifyOptions) checksumVerifyResult {
+	result := checksumVerifyResultFor(candidate)
+	if candidate.DeleteMarker {
+		result.Result = checksumResultSkippedDeleteMarker
+		return result
+	}
+
+	resource := candidate.Alias + "/" + candidate.Bucket + "/" + candidate.Key
+	sse := getSSE(resource, opts.Encryption[candidate.Alias])
+	info, err := backend.statObjectForChecksumVerify(ctx, candidate.Bucket, candidate.Key, candidate.VersionID, sse)
+	if err != nil {
+		return checksumVerifyErrorResult(candidate, err)
+	}
+	result.Size = info.Size
+	result.ETag = info.ETag
+	result.LastModified = &info.LastModified
+	result.ChecksumType = info.ChecksumType
+	result.StoredChecksums = mergeChecksumMaps(info.Checksums, info.UnsupportedChecksums)
+	if info.VersionID != "" {
+		result.VersionID = info.VersionID
+	}
+
+	if (opts.OlderThan != "" && isOlder(info.LastModified, opts.OlderThan)) ||
+		(opts.NewerThan != "" && isNewer(info.LastModified, opts.NewerThan)) {
+		result.Result = checksumResultSkippedTimeFilter
+		return result
+	}
+	if len(info.Checksums) == 0 && len(info.UnsupportedChecksums) == 0 {
+		result.Result = checksumResultNoChecksum
+		return result
+	}
+	if len(info.UnsupportedChecksums) > 0 {
+		result.Result = checksumResultUnknownChecksumAlgorithm
+		result.ErrorMessage = "object uses a checksum algorithm not supported by this command"
+		return result
+	}
+	switch info.ChecksumType {
+	case checksumVerifyFullObjectType:
+	case checksumVerifyCompositeType:
+		result.Result = checksumResultUnknownComposite
+		return result
+	default:
+		result.Result = checksumResultUnknownChecksumType
+		result.ErrorMessage = "checksum type is missing or unsupported"
+		return result
+	}
+	if info.Size < 0 {
+		result.Result = checksumResultUnknownReadError
+		result.ErrorMessage = "object size is unknown"
+		return result
+	}
+	if opts.MaximumSize > 0 && info.Size > opts.MaximumSize {
+		result.Result = checksumResultSkippedTooLarge
+		return result
+	}
+	if opts.DryRun {
+		result.Result = checksumResultWouldVerify
+		return result
+	}
+
+	readVersionID := candidate.VersionID
+	if readVersionID == "" && info.VersionID != "" {
+		readVersionID = info.VersionID
+	}
+	mutableVersion := readVersionID == "" || readVersionID == "null"
+	if mutableVersion && info.ETag == "" {
+		result.Result = checksumResultUnknownObjectChanged
+		result.ErrorMessage = "unversioned object did not return an ETag for If-Match"
+		return result
+	}
+	ifMatch := ""
+	if mutableVersion {
+		ifMatch = info.ETag
+	}
+	hashers, writers := checksumVerifyHashers(info.Checksums)
+	if len(writers) == 0 || len(hashers) != len(info.Checksums) {
+		result.Result = checksumResultUnknownChecksumAlgorithm
+		return result
+	}
+	reader, err := backend.getObjectForChecksumVerify(ctx, candidate.Bucket, candidate.Key, readVersionID, ifMatch, sse)
+	if err != nil {
+		return applyChecksumVerifyError(result, err)
+	}
+	read, readErr := io.Copy(io.MultiWriter(writers...), reader)
+	closeErr := reader.Close()
+	result.BytesRead = read
+	if readErr != nil {
+		result.Result = checksumResultUnknownReadError
+		result.ErrorMessage = readErr.Error()
+		return result
+	}
+	if closeErr != nil {
+		result.Result = checksumResultUnknownReadError
+		result.ErrorMessage = closeErr.Error()
+		return result
+	}
+	if read != info.Size {
+		result.Result = checksumResultUnknownShortRead
+		result.ErrorMessage = fmt.Sprintf("read %d bytes, expected %d", read, info.Size)
+		return result
+	}
+
+	if mutableVersion {
+		after, statErr := backend.statObjectForChecksumVerify(ctx, candidate.Bucket, candidate.Key, readVersionID, sse)
+		if statErr != nil {
+			return applyChecksumVerifyError(result, statErr)
+		}
+		if checksumVerifyObjectChanged(info, after) {
+			result.Result = checksumResultUnknownObjectChanged
+			return result
+		}
+	}
+
+	result.CalculatedChecksums = make(map[string]string, len(hashers))
+	result.Result = checksumResultMatch
+	for algorithm, hasher := range hashers {
+		calculated := base64.StdEncoding.EncodeToString(hasher.Sum(nil))
+		result.CalculatedChecksums[algorithm] = calculated
+		if calculated != info.Checksums[algorithm] {
+			result.Result = checksumResultMismatch
+		}
+	}
+	return result
+}
+
+func runChecksumVerifyWorkers(ctx context.Context, backend checksumVerifyBackend, candidates <-chan checksumVerifyCandidate, workers int, opts checksumVerifyOptions) <-chan checksumVerifyResult {
+	results := make(chan checksumVerifyResult)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case candidate, ok := <-candidates:
+					if !ok {
+						return
+					}
+					result := verifyChecksumCandidate(ctx, backend, candidate, opts)
+					select {
+					case <-ctx.Done():
+						return
+					case results <- result:
+					}
+				}
+			}
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+	return results
+}
+
+func mainChecksumVerify(cliCtx *cli.Context) error {
+	validateChecksumVerifySyntax(cliCtx)
+	ctx, cancel := context.WithCancel(globalContext)
+	defer cancel()
+
+	target := cliCtx.Args().First()
+	alias, path := url2Alias(target)
+	manifest := cliCtx.String("manifest")
+	if manifest != "" && path != "" {
+		fatalIf(errInvalidArgument(), "Manifest mode requires an alias without a bucket or prefix.")
+	}
+	client, err := newClient(target)
+	fatalIf(err.Trace(target), "Unable to initialize checksum verification target.")
+	s3Client, ok := client.(*S3Client)
+	if !ok {
+		fatalIf(errInvalidArgument(), "Checksum verification requires an S3-compatible alias.")
+	}
+
+	maximumSize, sizeErr := parseChecksumVerifyMaximumSize(cliCtx.String("max-size"))
+	fatalIf(probe.NewError(sizeErr), "Unable to parse --max-size.")
+	encryption, encErr := validateAndCreateEncryptionKeys(cliCtx)
+	fatalIf(encErr, "Unable to parse encryption keys.")
+	report, reportErr := openChecksumVerifyReport(cliCtx.String("report"))
+	fatalIf(probe.NewError(reportErr), "Unable to create checksum verification report.")
+
+	started := time.Now()
+	candidates := make(chan checksumVerifyCandidate)
+	producerErr := make(chan error, 1)
+	go func() {
+		defer close(candidates)
+		if manifest != "" {
+			producerErr <- readChecksumVerifyManifest(ctx, manifest, alias, candidates)
+			return
+		}
+		producerErr <- scanChecksumVerifyCandidates(ctx, s3Client, target, alias,
+			cliCtx.String("version-id"), cliCtx.Bool("recursive"), cliCtx.Bool("versions"), candidates)
+	}()
+
+	opts := checksumVerifyOptions{
+		DryRun:      cliCtx.Bool("dry-run"),
+		MaximumSize: maximumSize,
+		OlderThan:   cliCtx.String("older-than"),
+		NewerThan:   cliCtx.String("newer-than"),
+		FailOn:      strings.ToLower(cliCtx.String("fail-on")),
+		Encryption:  encryption,
+	}
+	summary := newChecksumVerifySummary(opts.DryRun)
+	var outputErr error
+	for result := range runChecksumVerifyWorkers(ctx, s3Client, candidates, cliCtx.Int("max-workers"), opts) {
+		summary.add(result)
+		if outputErr == nil {
+			outputErr = report.write(result)
+			if outputErr != nil {
+				cancel()
+			}
+		}
+		if !globalQuiet {
+			printMsg(result)
+		}
+	}
+	enumerationErr := <-producerErr
+	if enumerationErr != nil {
+		summary.Incomplete = true
+	}
+	summary.Duration = time.Since(started)
+	summary.Timestamp = UTCNow()
+	if outputErr == nil {
+		outputErr = report.write(summary)
+	}
+	if !globalQuiet {
+		printMsg(summary)
+	}
+	if closeErr := report.close(); outputErr == nil {
+		outputErr = closeErr
+	}
+	if outputErr != nil {
+		errorIf(probe.NewError(outputErr), "Unable to write checksum verification report")
+		return exitStatus(globalErrorExitStatus)
+	}
+	if enumerationErr != nil && !errors.Is(enumerationErr, context.Canceled) {
+		errorIf(probe.NewError(enumerationErr), "Unable to enumerate checksum verification candidates")
+		return exitStatus(globalErrorExitStatus)
+	}
+	if summary.shouldFail(opts.FailOn, opts.DryRun) {
+		return exitStatus(globalErrorExitStatus)
+	}
+	return nil
+}

--- a/cmd/checksum-verify_test.go
+++ b/cmd/checksum-verify_test.go
@@ -1,0 +1,792 @@
+// Copyright (c) 2015-2025 MinIO, Inc.
+// Copyright (c) 2025-2026 PGSTY
+//
+// This file is part of MinIO Client
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	minio "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/minio/minio-go/v7/pkg/encrypt"
+)
+
+type checksumVerifyFakeBackend struct {
+	mu             sync.Mutex
+	infos          []checksumVerifyObjectInfo
+	statErr        error
+	getErr         error
+	data           []byte
+	statCalls      int
+	getCalls       int
+	getVersionID   string
+	getIfMatchETag string
+}
+
+type checksumVerifyBlockingBackend struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+func (b *checksumVerifyBlockingBackend) statObjectForChecksumVerify(ctx context.Context, _, _, _ string, _ encrypt.ServerSide) (checksumVerifyObjectInfo, error) {
+	b.once.Do(func() { close(b.started) })
+	<-ctx.Done()
+	return checksumVerifyObjectInfo{}, ctx.Err()
+}
+
+func (b *checksumVerifyBlockingBackend) getObjectForChecksumVerify(context.Context, string, string, string, string, encrypt.ServerSide) (io.ReadCloser, error) {
+	return nil, errors.New("unexpected GET from blocking backend")
+}
+
+func (f *checksumVerifyFakeBackend) statObjectForChecksumVerify(_ context.Context, _, _, _ string, _ encrypt.ServerSide) (checksumVerifyObjectInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.statCalls++
+	if f.statErr != nil {
+		return checksumVerifyObjectInfo{}, f.statErr
+	}
+	if len(f.infos) == 0 {
+		return checksumVerifyObjectInfo{}, errors.New("missing fake object info")
+	}
+	index := min(f.statCalls-1, len(f.infos)-1)
+	return f.infos[index], nil
+}
+
+func (f *checksumVerifyFakeBackend) getObjectForChecksumVerify(_ context.Context, _, _, versionID, ifMatchETag string, _ encrypt.ServerSide) (io.ReadCloser, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getCalls++
+	f.getVersionID = versionID
+	f.getIfMatchETag = ifMatchETag
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return io.NopCloser(bytes.NewReader(f.data)), nil
+}
+
+func checksumForTest(t *testing.T, typ minio.ChecksumType, data []byte) string {
+	t.Helper()
+	h := typ.Hasher()
+	if h == nil {
+		t.Fatal("missing checksum hasher")
+	}
+	if _, err := h.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+func fullObjectInfo(data []byte, checksums map[string]string) checksumVerifyObjectInfo {
+	return checksumVerifyObjectInfo{
+		Size:         int64(len(data)),
+		ETag:         "test-etag",
+		LastModified: time.Unix(100, 0).UTC(),
+		VersionID:    "version-1",
+		ChecksumType: checksumVerifyFullObjectType,
+		Checksums:    checksums,
+	}
+}
+
+func TestVerifyChecksumCandidate(t *testing.T) {
+	data := []byte("logical object bytes")
+	crc32Value := checksumForTest(t, minio.ChecksumCRC32, data)
+	sha256Value := checksumForTest(t, minio.ChecksumSHA256, data)
+	candidate := checksumVerifyCandidate{Alias: "play", Bucket: "archive", Key: "object", VersionID: "version-1"}
+	baseOptions := checksumVerifyOptions{FailOn: "any", Encryption: map[string][]prefixSSEPair{}}
+
+	tests := []struct {
+		name        string
+		backend     *checksumVerifyFakeBackend
+		opts        checksumVerifyOptions
+		wantResult  string
+		wantGet     int
+		wantVersion string
+	}{
+		{
+			name: "match multiple algorithms",
+			backend: &checksumVerifyFakeBackend{
+				infos: []checksumVerifyObjectInfo{fullObjectInfo(data, map[string]string{"CRC32": crc32Value, "SHA256": sha256Value})},
+				data:  data,
+			},
+			opts:        baseOptions,
+			wantResult:  checksumResultMatch,
+			wantGet:     1,
+			wantVersion: "version-1",
+		},
+		{
+			name: "mismatch",
+			backend: &checksumVerifyFakeBackend{
+				infos: []checksumVerifyObjectInfo{fullObjectInfo(data, map[string]string{"CRC32": "AAAAAA=="})},
+				data:  data,
+			},
+			opts:        baseOptions,
+			wantResult:  checksumResultMismatch,
+			wantGet:     1,
+			wantVersion: "version-1",
+		},
+		{
+			name: "one of multiple algorithms mismatches",
+			backend: &checksumVerifyFakeBackend{
+				infos: []checksumVerifyObjectInfo{fullObjectInfo(data, map[string]string{"CRC32": crc32Value, "SHA256": "AAAAAA=="})},
+				data:  data,
+			},
+			opts:        baseOptions,
+			wantResult:  checksumResultMismatch,
+			wantGet:     1,
+			wantVersion: "version-1",
+		},
+		{
+			name: "no checksum avoids get",
+			backend: &checksumVerifyFakeBackend{
+				infos: []checksumVerifyObjectInfo{fullObjectInfo(data, nil)},
+			},
+			opts:       baseOptions,
+			wantResult: checksumResultNoChecksum,
+		},
+		{
+			name: "composite avoids get",
+			backend: &checksumVerifyFakeBackend{
+				infos: []checksumVerifyObjectInfo{{
+					Size:         int64(len(data)),
+					ChecksumType: checksumVerifyCompositeType,
+					Checksums:    map[string]string{"CRC32": crc32Value + "-2"},
+				}},
+			},
+			opts:       baseOptions,
+			wantResult: checksumResultUnknownComposite,
+		},
+		{
+			name: "missing checksum type avoids get",
+			backend: &checksumVerifyFakeBackend{
+				infos: []checksumVerifyObjectInfo{{Size: int64(len(data)), Checksums: map[string]string{"CRC32": crc32Value}}},
+			},
+			opts:       baseOptions,
+			wantResult: checksumResultUnknownChecksumType,
+		},
+		{
+			name: "unsupported checksum avoids get",
+			backend: &checksumVerifyFakeBackend{
+				infos: []checksumVerifyObjectInfo{{
+					Size:                 int64(len(data)),
+					ChecksumType:         checksumVerifyFullObjectType,
+					UnsupportedChecksums: map[string]string{"SHA512": "value"},
+				}},
+			},
+			opts:       baseOptions,
+			wantResult: checksumResultUnknownChecksumAlgorithm,
+		},
+		{
+			name: "dry run avoids get",
+			backend: &checksumVerifyFakeBackend{
+				infos: []checksumVerifyObjectInfo{fullObjectInfo(data, map[string]string{"CRC32": crc32Value})},
+			},
+			opts: func() checksumVerifyOptions {
+				opts := baseOptions
+				opts.DryRun = true
+				return opts
+			}(),
+			wantResult: checksumResultWouldVerify,
+		},
+		{
+			name: "maximum size avoids get",
+			backend: &checksumVerifyFakeBackend{
+				infos: []checksumVerifyObjectInfo{fullObjectInfo(data, map[string]string{"CRC32": crc32Value})},
+			},
+			opts: func() checksumVerifyOptions {
+				opts := baseOptions
+				opts.MaximumSize = int64(len(data) - 1)
+				return opts
+			}(),
+			wantResult: checksumResultSkippedTooLarge,
+		},
+		{
+			name: "short read",
+			backend: &checksumVerifyFakeBackend{
+				infos: []checksumVerifyObjectInfo{fullObjectInfo(append(data, 'x'), map[string]string{"CRC32": crc32Value})},
+				data:  data,
+			},
+			opts:        baseOptions,
+			wantResult:  checksumResultUnknownShortRead,
+			wantGet:     1,
+			wantVersion: "version-1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := verifyChecksumCandidate(context.Background(), tc.backend, candidate, tc.opts)
+			if result.Result != tc.wantResult {
+				t.Fatalf("result %q, want %q: %+v", result.Result, tc.wantResult, result)
+			}
+			if tc.backend.getCalls != tc.wantGet {
+				t.Fatalf("GET calls %d, want %d", tc.backend.getCalls, tc.wantGet)
+			}
+			if tc.backend.getVersionID != tc.wantVersion {
+				t.Fatalf("GET version %q, want %q", tc.backend.getVersionID, tc.wantVersion)
+			}
+			if tc.backend.getIfMatchETag != "" {
+				t.Fatalf("version-pinned GET unexpectedly used If-Match %q", tc.backend.getIfMatchETag)
+			}
+			if tc.backend.statCalls != 1 {
+				t.Fatalf("version-pinned candidate used %d HEAD requests, want 1", tc.backend.statCalls)
+			}
+		})
+	}
+}
+
+func TestVerifyChecksumCandidateAllAlgorithms(t *testing.T) {
+	data := []byte("all supported checksum algorithms")
+	candidate := checksumVerifyCandidate{Alias: "play", Bucket: "archive", Key: "object", VersionID: "version-1"}
+	for _, algorithm := range checksumVerifyAlgorithms {
+		t.Run(algorithm.Name, func(t *testing.T) {
+			backend := &checksumVerifyFakeBackend{
+				infos: []checksumVerifyObjectInfo{fullObjectInfo(data, map[string]string{
+					algorithm.Name: checksumForTest(t, algorithm.Type, data),
+				})},
+				data: data,
+			}
+			result := verifyChecksumCandidate(context.Background(), backend, candidate,
+				checksumVerifyOptions{Encryption: map[string][]prefixSSEPair{}},
+			)
+			if result.Result != checksumResultMatch {
+				t.Fatalf("result %q, want %q: %+v", result.Result, checksumResultMatch, result)
+			}
+		})
+	}
+}
+
+func TestVerifyChecksumCandidateUnversionedConsistency(t *testing.T) {
+	data := []byte("unversioned data")
+	value := checksumForTest(t, minio.ChecksumCRC32C, data)
+	for _, versionID := range []string{"", "null"} {
+		versionName := versionID
+		if versionName == "" {
+			versionName = "empty"
+		}
+		for _, changed := range []bool{false, true} {
+			name := versionName + "/unchanged"
+			if changed {
+				name = versionName + "/changed"
+			}
+			t.Run(name, func(t *testing.T) {
+				before := fullObjectInfo(data, map[string]string{"CRC32C": value})
+				before.VersionID = versionID
+				after := before
+				if changed {
+					after.ETag = "changed"
+				}
+				backend := &checksumVerifyFakeBackend{infos: []checksumVerifyObjectInfo{before, after}, data: data}
+				result := verifyChecksumCandidate(context.Background(), backend,
+					checksumVerifyCandidate{Alias: "play", Bucket: "archive", Key: "object", VersionID: versionID},
+					checksumVerifyOptions{Encryption: map[string][]prefixSSEPair{}},
+				)
+				wantResult := checksumResultMatch
+				if changed {
+					wantResult = checksumResultUnknownObjectChanged
+				}
+				if result.Result != wantResult {
+					t.Fatalf("result %q, want %q", result.Result, wantResult)
+				}
+				if backend.getVersionID != versionID {
+					t.Fatalf("GET version %q, want %q", backend.getVersionID, versionID)
+				}
+				if backend.getIfMatchETag != before.ETag {
+					t.Fatalf("If-Match %q, want %q", backend.getIfMatchETag, before.ETag)
+				}
+				if backend.statCalls != 2 {
+					t.Fatalf("stat calls %d, want 2", backend.statCalls)
+				}
+			})
+		}
+	}
+}
+
+func TestReadChecksumVerifyManifest(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.jsonl")
+	data := []byte("\n" +
+		`{"bucket":"archive","key":"one","versionId":"v1"}` + "\n" +
+		`{"bucket":"archive","key":"two"}` + "\n")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out := make(chan checksumVerifyCandidate, 2)
+	if err := readChecksumVerifyManifest(context.Background(), path, "play", out); err != nil {
+		t.Fatal(err)
+	}
+	close(out)
+	var got []checksumVerifyCandidate
+	for candidate := range out {
+		got = append(got, candidate)
+	}
+	want := []checksumVerifyCandidate{
+		{Alias: "play", Bucket: "archive", Key: "one", VersionID: "v1"},
+		{Alias: "play", Bucket: "archive", Key: "two"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("manifest entries %#v, want %#v", got, want)
+	}
+
+	badPath := filepath.Join(dir, "bad.jsonl")
+	if err := os.WriteFile(badPath, []byte(`{"bucket":"archive","key":"one","unexpected":true}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := readChecksumVerifyManifest(context.Background(), badPath, "play", make(chan checksumVerifyCandidate, 1)); err == nil {
+		t.Fatal("expected unknown manifest field to fail")
+	}
+	trailingPath := filepath.Join(dir, "trailing.jsonl")
+	if err := os.WriteFile(trailingPath, []byte(`{"bucket":"archive","key":"one"} {"bucket":"archive","key":"two"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := readChecksumVerifyManifest(context.Background(), trailingPath, "play", make(chan checksumVerifyCandidate, 1)); err == nil {
+		t.Fatal("expected multiple JSON values on one manifest line to fail")
+	}
+}
+
+func TestChecksumVerifyReportPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "report.jsonl")
+	report, err := openChecksumVerifyReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = report.write(checksumVerifyResult{SchemaVersion: 1, Type: "object", Result: checksumResultMatch}); err != nil {
+		t.Fatal(err)
+	}
+	if err = report.close(); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("report mode %o, want 600", got)
+	}
+	if _, err = openChecksumVerifyReport(path); err == nil {
+		t.Fatal("expected existing report file to be rejected")
+	}
+}
+
+func TestChecksumVerifySummaryFailOn(t *testing.T) {
+	summary := newChecksumVerifySummary(false)
+	summary.add(checksumVerifyResult{Result: checksumResultMismatch})
+	summary.add(checksumVerifyResult{Result: checksumResultUnknownReadError})
+	for _, tc := range []struct {
+		failOn string
+		want   bool
+	}{
+		{failOn: "none", want: false},
+		{failOn: "mismatch", want: true},
+		{failOn: "unknown", want: true},
+		{failOn: "any", want: true},
+	} {
+		if got := summary.shouldFail(tc.failOn, false); got != tc.want {
+			t.Fatalf("fail-on %q = %t, want %t", tc.failOn, got, tc.want)
+		}
+	}
+	if summary.shouldFail("any", true) {
+		t.Fatal("dry-run findings must not trigger --fail-on")
+	}
+	noChecksum := newChecksumVerifySummary(false)
+	noChecksum.add(checksumVerifyResult{Result: checksumResultNoChecksum})
+	if !strings.Contains(noChecksum.String(), "1 no-checksum") {
+		t.Fatalf("human summary does not disclose no-checksum count: %q", noChecksum.String())
+	}
+}
+
+func TestApplyChecksumVerifyError(t *testing.T) {
+	base := checksumVerifyResult{SchemaVersion: 1, Type: "object", Bucket: "archive", Key: "object", Size: 42}
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "access denied",
+			err:  minio.ErrorResponse{Code: "AccessDenied", StatusCode: http.StatusForbidden, Message: "denied"},
+			want: checksumResultUnknownAccessDenied,
+		},
+		{
+			name: "invalid object state precedes generic 403",
+			err:  minio.ErrorResponse{Code: "InvalidObjectState", StatusCode: http.StatusForbidden, Message: "restore required"},
+			want: checksumResultUnknownStorageClass,
+		},
+		{
+			name: "nonstandard 412",
+			err:  minio.ErrorResponse{Code: "VendorObjectChanged", StatusCode: http.StatusPreconditionFailed, Message: "changed"},
+			want: checksumResultUnknownObjectChanged,
+		},
+		{
+			name: "kms service error",
+			err:  minio.ErrorResponse{Code: "KMSNotConfigured", StatusCode: http.StatusInternalServerError, Message: "kms unavailable"},
+			want: checksumResultUnknownKMSError,
+		},
+		{
+			name: "kms in URL does not change network classification",
+			err:  &url.Error{Op: "GET", URL: "https://example.test/kms-object", Err: errors.New("connection reset")},
+			want: checksumResultUnknownReadError,
+		},
+		{
+			name: "silo missing SSE-C parameters",
+			err: minio.ErrorResponse{
+				Code:       "InvalidRequest",
+				StatusCode: http.StatusBadRequest,
+				Message:    "The object was stored using a form of Server Side Encryption. The correct parameters must be provided to retrieve the object.",
+			},
+			want: checksumResultUnknownSSECKeyMissing,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applyChecksumVerifyError(base, tc.err)
+			if got.Result != tc.want {
+				t.Fatalf("result %q, want %q", got.Result, tc.want)
+			}
+			if got.Size != base.Size {
+				t.Fatalf("error classification dropped prior HEAD metadata: %+v", got)
+			}
+		})
+	}
+}
+
+func TestValidateChecksumVerifySelection(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifest  string
+		versionID string
+		versions  bool
+		recursive bool
+		older     string
+		workers   int
+		failOn    string
+		wantErr   bool
+	}{
+		{name: "default", workers: 4, failOn: "any"},
+		{name: "manifest", manifest: "candidates.jsonl", workers: 4, failOn: "none"},
+		{name: "version recursive conflict", versionID: "v1", recursive: true, workers: 4, failOn: "any", wantErr: true},
+		{name: "manifest version conflict", manifest: "candidates.jsonl", versions: true, workers: 4, failOn: "any", wantErr: true},
+		{name: "manifest time conflict", manifest: "candidates.jsonl", older: "7d", workers: 4, failOn: "any", wantErr: true},
+		{name: "zero workers", workers: 0, failOn: "any", wantErr: true},
+		{name: "too many workers", workers: checksumVerifyMaximumWorkers + 1, failOn: "any", wantErr: true},
+		{name: "bad fail-on", workers: 4, failOn: "everything", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateChecksumVerifySelection(tc.manifest, tc.versionID, tc.versions, tc.recursive, tc.older, "", tc.workers, tc.failOn)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("error %v, wantErr=%t", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestScanChecksumVerifyCandidatesDirectModes(t *testing.T) {
+	tests := []struct {
+		name      string
+		targetURL string
+		target    string
+		versionID string
+		recursive bool
+		versions  bool
+		want      []checksumVerifyCandidate
+		wantErr   bool
+	}{
+		{
+			name:      "one current object",
+			targetURL: "https://example.test/archive/object",
+			target:    "play/archive/object",
+			want:      []checksumVerifyCandidate{{Alias: "play", Bucket: "archive", Key: "object"}},
+		},
+		{
+			name:      "one exact version",
+			targetURL: "https://example.test/archive/object",
+			target:    "play/archive/object",
+			versionID: "v1",
+			want:      []checksumVerifyCandidate{{Alias: "play", Bucket: "archive", Key: "object", VersionID: "v1"}},
+		},
+		{
+			name:      "bucket requires recursive",
+			targetURL: "https://example.test/archive",
+			target:    "play/archive",
+			wantErr:   true,
+		},
+		{
+			name:      "prefix requires recursive",
+			targetURL: "https://example.test/archive/prefix/",
+			target:    "play/archive/prefix/",
+			wantErr:   true,
+		},
+		{
+			name:      "version requires object",
+			targetURL: "https://example.test/archive",
+			target:    "play/archive",
+			versionID: "v1",
+			wantErr:   true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &S3Client{targetURL: newClientURL(tc.targetURL)}
+			out := make(chan checksumVerifyCandidate, 4)
+			err := scanChecksumVerifyCandidates(context.Background(), client, tc.target, "play", tc.versionID, tc.recursive, tc.versions, out)
+			close(out)
+			var got []checksumVerifyCandidate
+			for candidate := range out {
+				got = append(got, candidate)
+			}
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("error %v, wantErr=%t", err, tc.wantErr)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("candidates %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestScanChecksumVerifyCandidatesExactVersions(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !r.URL.Query().Has("versions") {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = io.WriteString(w, `<ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">`+
+			`<Name>archive</Name><Prefix>object</Prefix><KeyMarker></KeyMarker><VersionIdMarker></VersionIdMarker>`+
+			`<MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated>`+
+			`<Version><Key>object</Key><VersionId>v2</VersionId><IsLatest>true</IsLatest>`+
+			`<LastModified>2026-08-28T00:00:00Z</LastModified><ETag>"etag-v2"</ETag><Size>12</Size><StorageClass>STANDARD</StorageClass></Version>`+
+			`<Version><Key>object-child</Key><VersionId>child</VersionId><IsLatest>true</IsLatest>`+
+			`<LastModified>2026-08-28T00:00:00Z</LastModified><ETag>"etag-child"</ETag><Size>12</Size><StorageClass>STANDARD</StorageClass></Version>`+
+			`<DeleteMarker><Key>object</Key><VersionId>deleted</VersionId><IsLatest>false</IsLatest>`+
+			`<LastModified>2026-08-27T00:00:00Z</LastModified></DeleteMarker>`+
+			`</ListVersionsResult>`)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	endpoint, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api, err := minio.New(endpoint.Host, &minio.Options{
+		Creds:  credentials.NewStaticV4("access", "secret", ""),
+		Secure: false,
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &S3Client{api: api, targetURL: newClientURL(server.URL + "/archive/object")}
+	out := make(chan checksumVerifyCandidate, 4)
+	if err = scanChecksumVerifyCandidates(context.Background(), client, "play/archive/object", "play", "", false, true, out); err != nil {
+		t.Fatal(err)
+	}
+	close(out)
+	var got []checksumVerifyCandidate
+	for candidate := range out {
+		got = append(got, candidate)
+	}
+	want := []checksumVerifyCandidate{
+		{Alias: "play", Bucket: "archive", Key: "object", VersionID: "v2"},
+		{Alias: "play", Bucket: "archive", Key: "object", VersionID: "deleted", DeleteMarker: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("candidates %#v, want %#v", got, want)
+	}
+}
+
+func TestRunChecksumVerifyWorkersReturnsEveryResult(t *testing.T) {
+	data := []byte("worker pool data")
+	value := checksumForTest(t, minio.ChecksumCRC32, data)
+	backend := &checksumVerifyFakeBackend{
+		infos: []checksumVerifyObjectInfo{fullObjectInfo(data, map[string]string{"CRC32": value})},
+		data:  data,
+	}
+	const candidateCount = 32
+	candidates := make(chan checksumVerifyCandidate, candidateCount)
+	for i := range candidateCount {
+		candidates <- checksumVerifyCandidate{
+			Alias:     "play",
+			Bucket:    "archive",
+			Key:       fmt.Sprintf("object-%d", i),
+			VersionID: "version-1",
+		}
+	}
+	close(candidates)
+
+	results := runChecksumVerifyWorkers(context.Background(), backend, candidates, 4,
+		checksumVerifyOptions{Encryption: map[string][]prefixSSEPair{}},
+	)
+	var got int
+	for result := range results {
+		if result.Result != checksumResultMatch {
+			t.Fatalf("result %q, want MATCH", result.Result)
+		}
+		got++
+	}
+	if got != candidateCount {
+		t.Fatalf("received %d results, want %d", got, candidateCount)
+	}
+	if backend.getCalls != candidateCount {
+		t.Fatalf("GET calls %d, want %d", backend.getCalls, candidateCount)
+	}
+}
+
+func TestRunChecksumVerifyWorkersCancelTerminates(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	backend := &checksumVerifyBlockingBackend{started: make(chan struct{})}
+	candidates := make(chan checksumVerifyCandidate, 1)
+	candidates <- checksumVerifyCandidate{Alias: "play", Bucket: "archive", Key: "object"}
+	close(candidates)
+	results := runChecksumVerifyWorkers(ctx, backend, candidates, 1,
+		checksumVerifyOptions{Encryption: map[string][]prefixSSEPair{}},
+	)
+	done := make(chan struct{})
+	var drained int
+	go func() {
+		for range results {
+			drained++
+		}
+		close(done)
+	}()
+	select {
+	case <-backend.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not start verification")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker pool did not terminate after cancellation")
+	}
+	if drained > 1 {
+		t.Fatalf("drained %d results from one canceled candidate, want at most 1", drained)
+	}
+}
+
+func TestS3ChecksumVerifyHelpersAreReadOnly(t *testing.T) {
+	data := []byte("logical body")
+	checksum := checksumForTest(t, minio.ChecksumCRC32, data)
+	var mu sync.Mutex
+	var methods []string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		methods = append(methods, r.Method)
+		mu.Unlock()
+		if r.Method != http.MethodHead && r.Method != http.MethodGet {
+			t.Errorf("unexpected write method %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/archive/object" {
+			t.Errorf("path %q, want /archive/object", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if got := r.URL.Query().Get("versionId"); got != "v1" {
+			t.Errorf("versionId %q, want v1", got)
+		}
+		switch r.Method {
+		case http.MethodHead:
+			if got := r.Header.Get("x-amz-checksum-mode"); got != "ENABLED" {
+				t.Errorf("HEAD checksum mode %q, want ENABLED", got)
+			}
+			w.Header().Set("Content-Length", "12")
+			w.Header().Set("Last-Modified", time.Unix(100, 0).UTC().Format(http.TimeFormat))
+			w.Header().Set("ETag", `"test-etag"`)
+			w.Header().Set("X-Amz-Version-Id", "v1")
+			w.Header().Set("X-Amz-Checksum-Type", checksumVerifyFullObjectType)
+			w.Header().Set("X-Amz-Checksum-Crc32", checksum)
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if got := r.Header.Get("x-amz-checksum-mode"); got != "" {
+				t.Errorf("GET unexpectedly enabled automatic checksum mode: %q", got)
+			}
+			if got := r.Header.Get("Accept-Encoding"); got != "identity" {
+				t.Errorf("Accept-Encoding %q, want identity", got)
+			}
+			if got := r.Header.Get("If-Match"); got != `"test-etag"` {
+				t.Errorf("If-Match %q, want quoted ETag", got)
+			}
+			w.Header().Set("Content-Length", "12")
+			w.Header().Set("Last-Modified", time.Unix(100, 0).UTC().Format(http.TimeFormat))
+			w.Header().Set("ETag", `"test-etag"`)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+		}
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	endpoint, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api, err := minio.New(endpoint.Host, &minio.Options{
+		Creds:  credentials.NewStaticV4("access", "secret", ""),
+		Secure: false,
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &S3Client{api: api, targetURL: newClientURL(server.URL)}
+	info, err := client.statObjectForChecksumVerify(context.Background(), "archive", "object", "v1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.ChecksumType != checksumVerifyFullObjectType || info.Checksums["CRC32"] != checksum {
+		t.Fatalf("stat info %+v does not preserve checksum metadata", info)
+	}
+	reader, err := client.getObjectForChecksumVerify(context.Background(), "archive", "object", "v1", "test-etag", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("body %q, want %q", got, data)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !reflect.DeepEqual(methods, []string{http.MethodHead, http.MethodGet}) {
+		t.Fatalf("methods %v, want only HEAD and GET", methods)
+	}
+}

--- a/cmd/checksum-verify_test.go
+++ b/cmd/checksum-verify_test.go
@@ -34,6 +34,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -393,8 +394,10 @@ func TestChecksumVerifyReportPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := info.Mode().Perm(); got != 0o600 {
-		t.Fatalf("report mode %o, want 600", got)
+	if runtime.GOOS != "windows" {
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("report mode %o, want 600", got)
+		}
 	}
 	if _, err = openChecksumVerifyReport(path); err == nil {
 		t.Fatal("expected existing report file to be rejected")

--- a/cmd/checksum-verify_test.go
+++ b/cmd/checksum-verify_test.go
@@ -19,9 +19,11 @@
 package cmd
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -29,6 +31,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -39,6 +42,7 @@ import (
 	minio "github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
+	"github.com/minio/pkg/v3/console"
 )
 
 type checksumVerifyFakeBackend struct {
@@ -788,5 +792,343 @@ func TestS3ChecksumVerifyHelpersAreReadOnly(t *testing.T) {
 	defer mu.Unlock()
 	if !reflect.DeepEqual(methods, []string{http.MethodHead, http.MethodGet}) {
 		t.Fatalf("methods %v, want only HEAD and GET", methods)
+	}
+}
+
+const checksumVerifyCLIHelperEnv = "MC_CHECKSUM_VERIFY_CLI_HELPER"
+
+type checksumVerifyCLIResult struct {
+	stdout   []byte
+	stderr   []byte
+	exitCode int
+}
+
+type checksumVerifyCLIRecord struct {
+	Type   string `json:"type"`
+	Result string `json:"result"`
+}
+
+func TestChecksumVerifyCLIHelper(_ *testing.T) {
+	if os.Getenv(checksumVerifyCLIHelperEnv) != "1" {
+		return
+	}
+	separator := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator < 0 {
+		console.Fatalln("checksum verify CLI helper is missing --")
+	}
+	args := append([]string{"mcli"}, os.Args[separator+1:]...)
+	if err := Main(args); err != nil {
+		console.Fatalln(err)
+	}
+	os.Exit(0)
+}
+
+func newChecksumVerifyCLIServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	data := []byte("checksum verify CLI output contract")
+	checksum := checksumForTest(t, minio.ChecksumCRC32, data)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Query().Has("location") {
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = io.WriteString(w, `<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">us-east-1</LocationConstraint>`)
+			return
+		}
+
+		if !strings.HasPrefix(r.URL.Path, "/archive/") {
+			http.NotFound(w, r)
+			return
+		}
+		object := strings.TrimPrefix(r.URL.Path, "/archive/")
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", fmt.Sprint(len(data)))
+			w.Header().Set("Last-Modified", time.Unix(100, 0).UTC().Format(http.TimeFormat))
+			w.Header().Set("ETag", `"test-etag"`)
+			switch object {
+			case "match":
+				w.Header().Set("X-Amz-Checksum-Type", checksumVerifyFullObjectType)
+				w.Header().Set("X-Amz-Checksum-Crc32", checksum)
+			case "mismatch":
+				w.Header().Set("X-Amz-Checksum-Type", checksumVerifyFullObjectType)
+				w.Header().Set("X-Amz-Checksum-Crc32", "AAAAAA==")
+			case "unknown":
+				w.Header().Set("X-Amz-Checksum-Type", checksumVerifyCompositeType)
+				w.Header().Set("X-Amz-Checksum-Crc32", checksum+"-1")
+			default:
+				http.NotFound(w, r)
+			}
+		case http.MethodGet:
+			if object == "unknown" {
+				t.Errorf("unexpected GET for composite checksum object")
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if object != "match" && object != "mismatch" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Length", fmt.Sprint(len(data)))
+			w.Header().Set("Last-Modified", time.Unix(100, 0).UTC().Format(http.TimeFormat))
+			w.Header().Set("ETag", `"test-etag"`)
+			_, _ = w.Write(data)
+		default:
+			t.Errorf("unexpected method %s for %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+}
+
+func checksumVerifyCLIEnv(configDir, endpoint string, extra ...string) []string {
+	env := make([]string, 0, len(os.Environ())+5+len(extra))
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		upperKey := strings.ToUpper(key)
+		if strings.HasPrefix(upperKey, "MC_") || upperKey == "NO_PROXY" {
+			continue
+		}
+		env = append(env, entry)
+	}
+	host := strings.TrimPrefix(endpoint, "http://")
+	env = append(env,
+		checksumVerifyCLIHelperEnv+"=1",
+		"MC_CONFIG_DIR="+configDir,
+		"MC_HOST_b4=http://access:secret@"+host,
+		"NO_PROXY=127.0.0.1,localhost",
+	)
+	return append(env, extra...)
+}
+
+func checksumVerifyCLICommand(t *testing.T, endpoint string, extraEnv []string, args ...string) *exec.Cmd {
+	t.Helper()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	configDir := t.TempDir()
+	if err = os.WriteFile(filepath.Join(configDir, globalMCConfigFile), []byte("{\"version\":\"10\",\"aliases\":{}}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err = os.MkdirAll(filepath.Join(configDir, globalSharedURLsDataDir), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	helperArgs := append([]string{"-test.run=^TestChecksumVerifyCLIHelper$", "--"}, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	t.Cleanup(cancel)
+	command := exec.CommandContext(ctx, executable, helperArgs...)
+	// Keep config migration and User-Agent behavior identical on every platform.
+	command.Args[0] = "mcli"
+	command.Env = checksumVerifyCLIEnv(configDir, endpoint, extraEnv...)
+	return command
+}
+
+func checksumVerifyCLIExitCode(t *testing.T, command *exec.Cmd) int {
+	t.Helper()
+	err := command.Run()
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("running checksum verify CLI helper: %v", err)
+	}
+	return exitErr.ExitCode()
+}
+
+func runChecksumVerifyCLI(t *testing.T, endpoint string, extraEnv []string, args ...string) checksumVerifyCLIResult {
+	t.Helper()
+	command := checksumVerifyCLICommand(t, endpoint, extraEnv, args...)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	exitCode := checksumVerifyCLIExitCode(t, command)
+	return checksumVerifyCLIResult{
+		stdout:   stdout.Bytes(),
+		stderr:   stderr.Bytes(),
+		exitCode: exitCode,
+	}
+}
+
+func decodeChecksumVerifyJSONLines(t *testing.T, data []byte) []checksumVerifyCLIRecord {
+	t.Helper()
+	var records []checksumVerifyCLIRecord
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		var record checksumVerifyCLIRecord
+		if err := json.Unmarshal(scanner.Bytes(), &record); err != nil {
+			t.Fatalf("invalid checksum verify JSON line %q: %v", scanner.Text(), err)
+		}
+		records = append(records, record)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return records
+}
+
+func assertChecksumVerifyHumanOutput(t *testing.T, result checksumVerifyCLIResult, status string) {
+	t.Helper()
+	if result.exitCode != 0 {
+		t.Fatalf("exit code %d, want 0; stderr=%s", result.exitCode, result.stderr)
+	}
+	output := string(result.stdout)
+	firstLine, _, _ := strings.Cut(output, "\n")
+	if !strings.HasPrefix(firstLine, status+" ") || !strings.Contains(output, "Checksum verification:") {
+		t.Fatalf("stdout %q does not contain %s object and summary", output, status)
+	}
+	if len(result.stderr) != 0 {
+		t.Fatalf("stderr %q, want empty", result.stderr)
+	}
+}
+
+func TestChecksumVerifyCLIOutputContract(t *testing.T) {
+	server := newChecksumVerifyCLIServer(t)
+	defer server.Close()
+	base := []string{"checksum", "verify", "--max-workers", "1", "--fail-on", "none", "b4/archive/match"}
+
+	t.Run("non-TTY human pipe", func(t *testing.T) {
+		assertChecksumVerifyHumanOutput(t, runChecksumVerifyCLI(t, server.URL, nil, base...), checksumResultMatch)
+	})
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "JSON at app", args: append([]string{"--json"}, base...)},
+		{name: "JSON at parent", args: []string{"checksum", "--json", "verify", "--max-workers", "1", "--fail-on", "none", "b4/archive/match"}},
+		{name: "JSON at leaf", args: []string{"checksum", "verify", "--json", "--max-workers", "1", "--fail-on", "none", "b4/archive/match"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := runChecksumVerifyCLI(t, server.URL, nil, tc.args...)
+			if result.exitCode != 0 || len(result.stderr) != 0 {
+				t.Fatalf("exit code %d, stderr=%q", result.exitCode, result.stderr)
+			}
+			records := decodeChecksumVerifyJSONLines(t, result.stdout)
+			if len(records) != 2 || records[0].Type != "object" || records[0].Result != checksumResultMatch || records[1].Type != "summary" {
+				t.Fatalf("JSON Lines records %+v, want MATCH object and summary", records)
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		extraEnv []string
+	}{
+		{name: "quiet at app", args: append([]string{"--quiet"}, base...)},
+		{name: "quiet at parent", args: []string{"checksum", "--quiet", "verify", "--max-workers", "1", "--fail-on", "none", "b4/archive/match"}},
+		{name: "quiet at leaf", args: []string{"checksum", "verify", "--quiet", "--max-workers", "1", "--fail-on", "none", "b4/archive/match"}},
+		{name: "short quiet", args: []string{"checksum", "verify", "-q", "--max-workers", "1", "--fail-on", "none", "b4/archive/match"}},
+		{name: "quiet from environment", args: base, extraEnv: []string{"MC_QUIET=true"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := runChecksumVerifyCLI(t, server.URL, tc.extraEnv, tc.args...)
+			if result.exitCode != 0 || len(result.stdout) != 0 || len(result.stderr) != 0 {
+				t.Fatalf("exit=%d stdout=%q stderr=%q, want silent success", result.exitCode, result.stdout, result.stderr)
+			}
+		})
+	}
+
+	t.Run("quiet false", func(t *testing.T) {
+		args := append([]string{"--quiet=false"}, base...)
+		assertChecksumVerifyHumanOutput(t, runChecksumVerifyCLI(t, server.URL, nil, args...), checksumResultMatch)
+	})
+}
+
+func TestChecksumVerifyCLIRedirectAndReport(t *testing.T) {
+	server := newChecksumVerifyCLIServer(t)
+	defer server.Close()
+	base := []string{"checksum", "verify", "--max-workers", "1", "--fail-on", "none", "b4/archive/match"}
+
+	t.Run("regular file redirect", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "stdout.txt")
+		file, err := os.Create(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		command := checksumVerifyCLICommand(t, server.URL, nil, base...)
+		var stderr bytes.Buffer
+		command.Stdout = file
+		command.Stderr = &stderr
+		exitCode := checksumVerifyCLIExitCode(t, command)
+		if err = file.Close(); err != nil {
+			t.Fatal(err)
+		}
+		stdout, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertChecksumVerifyHumanOutput(t, checksumVerifyCLIResult{stdout: stdout, stderr: stderr.Bytes(), exitCode: exitCode}, checksumResultMatch)
+	})
+
+	for _, quiet := range []bool{false, true} {
+		name := "report with stdout"
+		if quiet {
+			name = "report with quiet"
+		}
+		t.Run(name, func(t *testing.T) {
+			reportPath := filepath.Join(t.TempDir(), "report.jsonl")
+			args := append([]string{}, base...)
+			args = append(args[:len(args)-1], "--report", reportPath, args[len(args)-1])
+			if quiet {
+				args = append([]string{"--quiet"}, args...)
+			}
+			result := runChecksumVerifyCLI(t, server.URL, nil, args...)
+			if result.exitCode != 0 || len(result.stderr) != 0 {
+				t.Fatalf("exit=%d stderr=%q", result.exitCode, result.stderr)
+			}
+			if quiet && len(result.stdout) != 0 {
+				t.Fatalf("quiet stdout %q, want empty", result.stdout)
+			}
+			if !quiet {
+				assertChecksumVerifyHumanOutput(t, result, checksumResultMatch)
+			}
+			report, err := os.ReadFile(reportPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			records := decodeChecksumVerifyJSONLines(t, report)
+			if len(records) != 2 || records[0].Type != "object" || records[1].Type != "summary" {
+				t.Fatalf("report records %+v, want object and summary", records)
+			}
+		})
+	}
+}
+
+func TestChecksumVerifyCLIFailOnExitStatus(t *testing.T) {
+	server := newChecksumVerifyCLIServer(t)
+	defer server.Close()
+	for _, tc := range []struct {
+		name       string
+		object     string
+		failOn     string
+		wantStatus string
+		wantExit   int
+	}{
+		{name: "mismatch fails", object: "mismatch", failOn: "mismatch", wantStatus: checksumResultMismatch, wantExit: 1},
+		{name: "mismatch ignored", object: "mismatch", failOn: "unknown", wantStatus: checksumResultMismatch},
+		{name: "unknown fails", object: "unknown", failOn: "unknown", wantStatus: checksumResultUnknownComposite, wantExit: 1},
+		{name: "unknown ignored", object: "unknown", failOn: "mismatch", wantStatus: checksumResultUnknownComposite},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := runChecksumVerifyCLI(t, server.URL, nil,
+				"checksum", "verify", "--max-workers", "1", "--fail-on", tc.failOn, "b4/archive/"+tc.object,
+			)
+			if result.exitCode != tc.wantExit {
+				t.Fatalf("exit code %d, want %d; stdout=%q stderr=%q", result.exitCode, tc.wantExit, result.stdout, result.stderr)
+			}
+			if len(result.stderr) != 0 {
+				t.Fatalf("stderr %q, want empty", result.stderr)
+			}
+			output := string(result.stdout)
+			if !strings.Contains(output, tc.wantStatus) || !strings.Contains(output, "Checksum verification:") {
+				t.Fatalf("stdout %q does not contain %s object and summary", output, tc.wantStatus)
+			}
+		})
 	}
 }

--- a/cmd/client-s3-checksum.go
+++ b/cmd/client-s3-checksum.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2015-2025 MinIO, Inc.
+// Copyright (c) 2025-2026 PGSTY
+//
+// This file is part of MinIO Client
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"context"
+	"io"
+	"strings"
+	"time"
+
+	minio "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/encrypt"
+)
+
+// checksumVerifyObjectInfo is deliberately separate from ClientContent.
+// Verification needs every checksum and the checksum type, while changing the
+// shared ClientContent conversion would also change existing stat output.
+type checksumVerifyObjectInfo struct {
+	Size                 int64
+	ETag                 string
+	LastModified         time.Time
+	VersionID            string
+	ChecksumType         string
+	Checksums            map[string]string
+	UnsupportedChecksums map[string]string
+}
+
+func (c *S3Client) statObjectForChecksumVerify(ctx context.Context, bucket, object, versionID string, sse encrypt.ServerSide) (checksumVerifyObjectInfo, error) {
+	opts := minio.StatObjectOptions{
+		ServerSideEncryption: sse,
+		VersionID:            versionID,
+		Checksum:             true,
+	}
+	info, err := c.api.StatObject(ctx, bucket, object, opts)
+	if err != nil {
+		return checksumVerifyObjectInfo{}, err
+	}
+
+	checksums := make(map[string]string, 5)
+	unsupported := make(map[string]string, 5)
+	set := func(dst map[string]string, algorithm, value string) {
+		if value != "" {
+			dst[algorithm] = value
+		}
+	}
+	for _, algorithm := range checksumVerifyAlgorithms {
+		set(checksums, algorithm.Name, algorithm.Value(info))
+	}
+	set(unsupported, "MD5", info.ChecksumMD5)
+	set(unsupported, "SHA512", info.ChecksumSHA512)
+	set(unsupported, "XXHASH64", info.ChecksumXXHash64)
+	set(unsupported, "XXHASH3", info.ChecksumXXHash3)
+	set(unsupported, "XXHASH128", info.ChecksumXXHash128)
+
+	return checksumVerifyObjectInfo{
+		Size:                 info.Size,
+		ETag:                 strings.Trim(info.ETag, `"`),
+		LastModified:         info.LastModified,
+		VersionID:            info.VersionID,
+		ChecksumType:         strings.ToUpper(info.ChecksumMode),
+		Checksums:            checksums,
+		UnsupportedChecksums: unsupported,
+	}, nil
+}
+
+// getObjectForChecksumVerify returns the raw logical object stream without
+// enabling minio-go's automatic checksum verification. The caller must consume
+// the stream to EOF and compare independently calculated values.
+func (c *S3Client) getObjectForChecksumVerify(ctx context.Context, bucket, object, versionID, ifMatchETag string, sse encrypt.ServerSide) (io.ReadCloser, error) {
+	opts := minio.GetObjectOptions{
+		ServerSideEncryption: sse,
+		VersionID:            versionID,
+	}
+	opts.Set("Accept-Encoding", "identity")
+	if ifMatchETag != "" {
+		if err := opts.SetMatchETag(strings.Trim(ifMatchETag, `"`)); err != nil {
+			return nil, err
+		}
+	}
+
+	core := minio.Core{Client: c.api}
+	reader, _, _, err := core.GetObject(ctx, bucket, object, opts)
+	return reader, err
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -401,6 +401,7 @@ var appCmds = []cli.Command{
 	adminCmd,
 	anonymousCmd,
 	batchCmd,
+	checksumCmd,
 	cpCmd,
 	catCmd,
 	corsCmd,

--- a/docs/checksum-verify.md
+++ b/docs/checksum-verify.md
@@ -159,7 +159,8 @@ object or establish correctness against an external source of truth.
 - `--older-than` and `--newer-than` reuse MCLI's existing relative-duration or
   absolute-time filters. Filtering still requires a HEAD so the decision uses
   the authoritative object version metadata.
-- Report files are newly created with mode `0600` and never contain object data
+- On POSIX systems, report files are newly created with mode `0600`; Windows
+  uses the account's filesystem ACLs. Reports never contain object data
   or SSE-C keys.
 - Tests must reject any unexpected write method at the mock S3 boundary.
 

--- a/docs/checksum-verify.md
+++ b/docs/checksum-verify.md
@@ -1,0 +1,168 @@
+# Checksum Verify Design
+
+## Decision
+
+MCLI provides a top-level, read-only verification workflow:
+
+```text
+mcli checksum verify ALIAS/BUCKET/OBJECT
+mcli checksum verify --recursive ALIAS/BUCKET[/PREFIX]
+mcli checksum verify --manifest candidates.jsonl ALIAS
+```
+
+The command verifies stored S3 additional checksums against the logical bytes
+returned by the object API. It does not identify the historical writer with
+certainty, inspect `xl.meta`, repair metadata, or write object data.
+
+The command is intentionally not under `admin`: version one uses only S3 data
+plane operations and should work with SILO, inherited MinIO data, and other
+compatible endpoints when the caller has sufficient object permissions.
+
+## Historical problem
+
+Older CopyObject paths could attach the server-side checksum hasher after
+destination compression. When checksum calculation was required, the stored S3
+checksum could therefore describe the compressed storage stream instead of the
+logical object bytes returned to clients. The object body could remain readable
+while checksum-aware clients reported a mismatch.
+
+Future writes are fixed in SILO Server. This command addresses only the missing
+read-only inventory and verification workflow for existing objects.
+
+## V1 scope
+
+Version one supports:
+
+- CRC32, CRC32C, CRC64NVME, SHA1, and SHA256;
+- checksums explicitly identified as `FULL_OBJECT`;
+- one object, a recursive bucket/prefix scan, all object versions, or an exact
+  VersionID;
+- a minimal JSON Lines candidate manifest;
+- SSE-C through the existing `--enc-c` prefix-to-key mapping;
+- dry-run cost estimation, bounded concurrency, download limiting, JSON output,
+  time and size filters, and an optional JSON Lines report.
+
+Version one does not support:
+
+- checksum repair, CopyObject, PUT, DELETE, or metadata mutation;
+- COMPOSITE checksum verification;
+- inferring checksum type from ETag;
+- `--rewind`, tier restore, server batch jobs, or automatic historical-cause
+  attribution.
+
+## Minimal manifest
+
+The manifest is an input candidate list, not a result or resume file. Each line
+contains only the exact object identity available from external audit logs or
+deployment records:
+
+```json
+{"bucket":"archive","key":"2025/report.json","versionId":"optional"}
+```
+
+`bucket` and `key` are required. `versionId` is optional. The endpoint alias is
+supplied once on the command line. Manifest mode is mutually exclusive with
+recursive, version, and time-selection flags.
+
+This deliberately small schema avoids placing checksums, object metadata, or
+encryption secrets in the candidate file. Resume and checkpoint semantics are
+deferred.
+
+## Dedicated S3 helper
+
+The command uses a dedicated private S3 helper rather than changing the shared
+`ClientContent` structure in the same change.
+
+The existing conversion to `ClientContent` does not retain ChecksumType and may
+overwrite earlier checksum values when more than one is present. Changing that
+shared behavior would also change existing `stat`, copy, mirror, and JSON output
+contracts. The dedicated helper keeps the initial verification patch isolated
+and reversible:
+
+1. `StatObject` is called with checksum mode enabled and an exact VersionID.
+2. All supported checksum values and ChecksumType are retained.
+3. `Core.GetObject` returns the logical object stream without enabling the SDK's
+   automatic checksum validator.
+4. For an unversioned or null version, GET uses the HEAD ETag as `If-Match`, and
+   a second HEAD checks that the object did not change during verification.
+
+The shared `ClientContent` checksum representation can be corrected in a
+separate compatibility change with its own `stat` and JSON regression review.
+
+## Result contract
+
+Every candidate produces one stable status. Important groups are:
+
+- `MATCH`: all supported stored checksums equal independently calculated values;
+- `MISMATCH`: at least one stored value differs;
+- `NO_CHECKSUM`: no additional checksum was stored, so the body is not read;
+- `WOULD_VERIFY`: dry-run found a supported full-object checksum;
+- `UNKNOWN_*`: verification could not make a reliable statement;
+- `SKIPPED_*`: the candidate was intentionally excluded by a filter.
+
+`UNKNOWN` is never converted into `MATCH`. The default `--fail-on any` returns a
+non-zero status for a mismatch or incomplete verification. MCLI's existing exit
+code convention is preserved: normal completion is 0, command failure is 1,
+and signals keep their existing codes. Detailed classification lives in the
+per-object JSON Lines records and final summary.
+
+`--fail-on` accepts `mismatch`, `unknown`, `any`, or `none`. It applies to
+completed object results, not fatal argument, authentication, enumeration, or
+report-write failures. Dry-run is an inventory operation and does not apply
+`--fail-on`; unsupported objects remain visible in its counts. `NO_CHECKSUM`
+means there was no stored additional checksum to compare and does not by itself
+make the command fail. Human and JSON summaries must show this count explicitly
+so an all-`NO_CHECKSUM` run cannot be mistaken for a fully verified data set.
+`unknown` matches only `UNKNOWN_*` results; use the default `any` to fail on both
+unknown results and checksum mismatches.
+
+The result means only:
+
+> The additional checksum returned by the endpoint at verification time does
+> or does not match the logical bytes returned at verification time.
+
+It does not by itself prove that the historical compression bug created the
+object or establish correctness against an external source of truth.
+
+## Safety and operational controls
+
+- Only LIST, HEAD, and GET are allowed.
+- `--dry-run` performs LIST and HEAD but no object-body GET.
+- FULL_OBJECT checksums are streamed through bounded hashers; bodies are never
+  buffered in full or written to disk.
+- The default worker count is four and the global download limit remains
+  available. `--max-workers` accepts values from 1 through 64.
+- `--max-size` allows large objects to be skipped explicitly.
+- `--older-than` and `--newer-than` reuse MCLI's existing relative-duration or
+  absolute-time filters. Filtering still requires a HEAD so the decision uses
+  the authoritative object version metadata.
+- Report files are newly created with mode `0600` and never contain object data
+  or SSE-C keys.
+- Tests must reject any unexpected write method at the mock S3 boundary.
+
+## Deferred work
+
+- COMPOSITE verification using paginated GetObjectAttributes part data;
+- checkpoint/resume and richer manifest generation;
+- an optional server-side read-only batch executor for very large estates;
+- any repair workflow;
+- correction of the shared `ClientContent` checksum representation.
+
+For an exact object's historical versions, the current client API lists the
+object-name prefix and filters exact key matches locally. This preserves correct
+results but can make a broad key prefix more expensive to enumerate; callers
+should prefer a manifest when an external log already provides exact VersionIDs.
+
+## Acceptance invariants
+
+The release test boundary keeps the following behavior explicit:
+
+- both an empty VersionID and the literal `null` version are treated as mutable,
+  use `If-Match`, and receive a post-read HEAD; a fixed VersionID uses neither;
+- if any one of several stored checksums differs, the object is `MISMATCH`;
+- `InvalidObjectState` is reported as a storage-class/restore condition before
+  the generic HTTP 403 access-denied classification;
+- normal worker completion returns exactly one result per candidate, and worker
+  cancellation closes the result stream without deadlock;
+- the known SILO missing-SSE-C-parameters response is classified without using
+  URL or object-name text, which could otherwise create false KMS/SSE labels.

--- a/docs/checksum-verify.md
+++ b/docs/checksum-verify.md
@@ -106,6 +106,27 @@ code convention is preserved: normal completion is 0, command failure is 1,
 and signals keep their existing codes. Detailed classification lives in the
 per-object JSON Lines records and final summary.
 
+### Output and automation contract
+
+Object records and the final summary are semantic command output. Unless the
+caller explicitly requests `--quiet`, `-q`, or `MC_QUIET=true`, they are written
+to stdout whether stdout is a terminal, a pipe, or a regular file. MCLI's
+automatic non-TTY quiet state exists to disable progress UI when terminal size
+is unavailable; it must not suppress checksum verification results.
+
+With `--json`, non-TTY stdout contains exactly one compact JSON value per line.
+TTY JSON retains MCLI's existing pretty presentation. The global flags are
+accepted at the app, `checksum`, and `verify` levels. The implementation checks
+the complete CLI context chain because `GlobalBool` stops at the nearest
+ancestor flag set and nested `Before` hooks can otherwise reset JSON Lines mode.
+
+`--report` is independent of stdout. It writes the same object records and final
+summary as JSON Lines even under explicit quiet, while stdout remains silent.
+Report creation/write failures and `--fail-on` continue to use the exit behavior
+defined below; the output fix does not turn findings into transport errors or
+change fatal-error formatting. See [pgsty/mc#5](https://github.com/pgsty/mc/issues/5)
+for the reproducer and release gate.
+
 `--fail-on` accepts `mismatch`, `unknown`, `any`, or `none`. It applies to
 completed object results, not fatal argument, authentication, enumeration, or
 report-write failures. Dry-run is an inventory operation and does not apply
@@ -113,8 +134,10 @@ report-write failures. Dry-run is an inventory operation and does not apply
 means there was no stored additional checksum to compare and does not by itself
 make the command fail. Human and JSON summaries must show this count explicitly
 so an all-`NO_CHECKSUM` run cannot be mistaken for a fully verified data set.
-`unknown` matches only `UNKNOWN_*` results; use the default `any` to fail on both
-unknown results and checksum mismatches.
+`unknown` matches only `UNKNOWN_*` results. The default `any` fails on checksum
+mismatches, `UNKNOWN_*`, and `SKIPPED_TOO_LARGE`, because an explicit size cap
+leaves the audit incomplete. Time-filter and delete-marker skips do not fail by
+themselves.
 
 The result means only:
 
@@ -164,5 +187,9 @@ The release test boundary keeps the following behavior explicit:
   the generic HTTP 403 access-denied classification;
 - normal worker completion returns exactly one result per candidate, and worker
   cancellation closes the result stream without deadlock;
+- a non-TTY pipe and a regular-file redirect receive every object record and the
+  final summary; non-TTY JSON is compact JSON Lines;
+- explicit quiet at the app, parent-command, or leaf-command position, the `-q`
+  alias, and `MC_QUIET=true` suppress stdout without suppressing `--report`;
 - the known SILO missing-SSE-C-parameters response is classified without using
   URL or object-name text, which could otherwise create false KMS/SSE labels.


### PR DESCRIPTION
## Summary

- add read-only `mcli checksum verify` object/version/prefix/manifest auditing
- classify MATCH, MISMATCH, NO_CHECKSUM, UNKNOWN and SKIPPED states without repair writes
- preserve object records and summaries in pipes, redirects and non-TTY JSON Lines unless quiet is explicitly requested
- document report, fail-on, SSE-C and output contracts

## Validation

- full unit and full race
- subprocess TTY/non-TTY/JSON/quiet/report/fail-on coverage
- real-S3 acceptance, vet, lint, brand, credits, dependency floors and crosscompile were completed on the original clean candidate
- clean six-binary GoReleaser provenance was verified

Refs #5. No tag or release is created by this PR.
