### PR TITLE
fix: validate policy writes strictly

### DIFF
--- a/cmd/admin-policy-create.go
+++ b/cmd/admin-policy-create.go
@@ -129,6 +129,9 @@ func mainAdminPolicyCreate(ctx *cli.Context) error {
 	policy, e := os.ReadFile(args.Get(2))
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to get policy")
 
+	_, e = parseNamedPolicyForWrite(policy)
+	fatalIf(probe.NewError(e).Trace(args...), "Unable to parse policy")
+
 	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Unable to initialize admin connection.")

--- a/cmd/admin-user-svcacct-add.go
+++ b/cmd/admin-user-svcacct-add.go
@@ -18,7 +18,6 @@
 package cmd
 
 import (
-	"bytes"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
@@ -33,7 +32,6 @@ import (
 	"github.com/minio/madmin-go/v3"
 	"github.com/minio/mc/pkg/probe"
 	"github.com/minio/pkg/v3/console"
-	"github.com/minio/pkg/v3/policy"
 )
 
 var adminUserSvcAcctAddFlags = []cli.Flag{
@@ -321,7 +319,7 @@ func mainAdminUserSvcAcctAdd(ctx *cli.Context) error {
 		policyBytes, e := os.ReadFile(policyPath)
 		fatalIf(probe.NewError(e), "unable to read the policy document")
 
-		p, e := policy.ParseConfig(bytes.NewReader(policyBytes))
+		p, e := parsePolicyForWrite(policyBytes)
 		fatalIf(probe.NewError(e), "unable to parse the policy document")
 
 		if p.IsEmpty() {

--- a/cmd/admin-user-svcacct-set.go
+++ b/cmd/admin-user-svcacct-set.go
@@ -111,6 +111,12 @@ func mainAdminUserSvcAcctSet(ctx *cli.Context) error {
 		var e error
 		buf, e = os.ReadFile(policyPath)
 		fatalIf(probe.NewError(e), "Unable to open the policy document.")
+
+		p, e := parsePolicyForWrite(buf)
+		fatalIf(probe.NewError(e), "Unable to parse the policy document.")
+		if p.IsEmpty() {
+			fatalIf(errInvalidArgument(), "empty policies are not allowed")
+		}
 	}
 
 	var expiryTime time.Time

--- a/cmd/idp-ldap-accesskey-create.go
+++ b/cmd/idp-ldap-accesskey-create.go
@@ -18,7 +18,6 @@
 package cmd
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -27,7 +26,6 @@ import (
 	"github.com/minio/cli"
 	"github.com/minio/madmin-go/v3"
 	"github.com/minio/mc/pkg/probe"
-	"github.com/minio/pkg/v3/policy"
 )
 
 var idpLdapAccesskeyCreateFlags = []cli.Flag{
@@ -181,7 +179,7 @@ func accessKeyCreateOpts(ctx *cli.Context, targetUser string) madmin.AddServiceA
 		policyBytes, e := os.ReadFile(policyPath)
 		fatalIf(probe.NewError(e), "unable to read the policy document")
 
-		p, e := policy.ParseConfig(bytes.NewReader(policyBytes))
+		p, e := parsePolicyForWrite(policyBytes)
 		fatalIf(probe.NewError(e), "unable to parse the policy document")
 
 		if p.IsEmpty() {

--- a/cmd/idp-ldap-accesskey-edit.go
+++ b/cmd/idp-ldap-accesskey-edit.go
@@ -18,7 +18,6 @@
 package cmd
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -27,7 +26,6 @@ import (
 	"github.com/minio/cli"
 	"github.com/minio/madmin-go/v3"
 	"github.com/minio/mc/pkg/probe"
-	"github.com/minio/pkg/v3/policy"
 )
 
 var idpLdapAccesskeyEditFlags = []cli.Flag{
@@ -138,7 +136,7 @@ func accessKeyEditOpts(ctx *cli.Context) madmin.UpdateServiceAccountReq {
 		policyBytes, e := os.ReadFile(policyPath)
 		fatalIf(probe.NewError(e), "unable to read the policy document")
 
-		p, e := policy.ParseConfig(bytes.NewReader(policyBytes))
+		p, e := parsePolicyForWrite(policyBytes)
 		fatalIf(probe.NewError(e), "unable to parse the policy document")
 
 		if p.IsEmpty() {

--- a/cmd/policy-validation.go
+++ b/cmd/policy-validation.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 PGSTY
+//
+// This file is part of the Silo object storage client.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package cmd
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/minio/pkg/v3/policy"
+)
+
+// Require the v3.12 policy implementation even when a consuming module
+// overrides mc's module replacement with its own silo-pkg version.
+var _ func(policy.Resource) bool = policy.Resource.IsBareARN
+
+// parsePolicyForWrite applies the strict validation required for new and
+// updated policy documents while read paths remain backward-compatible.
+func parsePolicyForWrite(policyBytes []byte) (*policy.Policy, error) {
+	return policy.ParseConfigStrict(bytes.NewReader(policyBytes))
+}
+
+// parseNamedPolicyForWrite also applies the server invariants for persisted
+// named policies. Session policies intentionally keep accepting an omitted
+// Version, matching SILO's service-account handlers.
+func parseNamedPolicyForWrite(policyBytes []byte) (*policy.Policy, error) {
+	p, err := parsePolicyForWrite(policyBytes)
+	if err != nil {
+		return nil, err
+	}
+	if p.IsEmpty() {
+		return nil, errors.New("empty policies are not allowed")
+	}
+	if p.Version == "" {
+		return nil, errors.New("policy version cannot be empty")
+	}
+	return p, nil
+}

--- a/cmd/policy-validation_test.go
+++ b/cmd/policy-validation_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 PGSTY
+//
+// This file is part of the Silo object storage client.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/minio/pkg/v3/policy"
+)
+
+func TestParsePolicyForWriteRejectsBareARNs(t *testing.T) {
+	testCases := []string{
+		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject"],"Resource":["arn:aws:s3:::"]}]}`,
+		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject"],"Resource":["*arn:aws:s3:::"]}]}`,
+		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject"],"NotResource":["arn:aws:s3:::"]}]}`,
+	}
+
+	for _, document := range testCases {
+		if _, err := policy.ParseConfig(strings.NewReader(document)); err != nil {
+			t.Fatalf("compatibility parser rejected stored policy: %v", err)
+		}
+		if _, err := parsePolicyForWrite([]byte(document)); err == nil {
+			t.Fatalf("strict write parser accepted bare ARN policy: %s", document)
+		}
+	}
+}
+
+func TestParsePolicyForWriteAcceptsExplicitResources(t *testing.T) {
+	document := []byte(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject"],"Resource":["arn:aws:s3:::bucket/*"]}]}`)
+
+	p, err := parsePolicyForWrite(document)
+	if err != nil {
+		t.Fatalf("strict write parser rejected explicit resource: %v", err)
+	}
+	if p.IsEmpty() {
+		t.Fatal("parsed policy is empty")
+	}
+}
+
+func TestParseNamedPolicyForWriteAppliesNamedPolicyInvariants(t *testing.T) {
+	testCases := []struct {
+		name     string
+		document string
+		wantErr  bool
+	}{
+		{
+			name:     "valid named policy",
+			document: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject"],"Resource":["arn:aws:s3:::bucket/*"]}]}`,
+		},
+		{
+			name:     "empty policy",
+			document: `{"Version":"2012-10-17","Statement":[]}`,
+			wantErr:  true,
+		},
+		{
+			name:     "missing version",
+			document: `{"Statement":[{"Effect":"Allow","Action":["s3:GetObject"],"Resource":["arn:aws:s3:::bucket/*"]}]}`,
+			wantErr:  true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := parseNamedPolicyForWrite([]byte(testCase.document))
+			if (err != nil) != testCase.wantErr {
+				t.Fatalf("parseNamedPolicyForWrite() error = %v, wantErr %v", err, testCase.wantErr)
+			}
+		})
+	}
+}
+
+func TestParsePolicyForWriteKeepsSessionPolicyVersionCompatibility(t *testing.T) {
+	document := []byte(`{"Statement":[{"Effect":"Allow","Action":["s3:GetObject"],"Resource":["arn:aws:s3:::bucket/*"]}]}`)
+
+	if _, err := parsePolicyForWrite(document); err != nil {
+		t.Fatalf("strict session-policy parser rejected an omitted version: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary\n\n- apply strict silo-pkg validation to named policy and service-account policy create/update paths\n- reject unknown fields, bare ARNs, Resource/NotResource conflicts, empty statements and missing Version for named policies\n- keep historical and session-policy read compatibility\n\n## Validation\n\n- full unit and full race from an isolated origin/main branch\n- focused policy-write race tests\n- clean diff and DCO\n\nThis is a client-side tightening and is independently revertible.