### PR TITLE
fix: use regular PUT for empty pipe input

### DIFF
--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -18,6 +18,9 @@
 package cmd
 
 import (
+	"bufio"
+	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -35,6 +38,19 @@ import (
 func defaultPartSize() string {
 	_, partSize, _, _ := minio.OptimalPartInfo(-1, 0)
 	return humanize.IBytes(uint64(partSize))
+}
+
+func preparePipeReader(reader io.Reader) (io.Reader, int64, error) {
+	// Give empty input a known size so it uses a regular zero-byte PUT
+	// instead of an unnecessary one-part multipart upload.
+	buffered := bufio.NewReader(reader)
+	if _, err := buffered.Peek(1); err != nil {
+		if errors.Is(err, io.EOF) {
+			return bytes.NewReader(nil), 0, nil
+		}
+		return nil, -1, err
+	}
+	return buffered, -1, nil
 }
 
 var pipeFlags = []cli.Flag{
@@ -168,9 +184,8 @@ func pipe(ctx *cli.Context, targetURL string, encKeyDB map[string][]prefixSSEPai
 		}
 	}
 
-	// Stream from stdin to multiple objects until EOF.
-	// Ignore size, since os.Stat() would not return proper size all the time
-	// for local filesystem for example /proc files.
+	// Stream non-empty stdin until EOF; empty input is identified below so it
+	// can use a regular zero-byte PUT instead of unknown-size multipart.
 	opts := PutOptions{
 		sse:              sseKey,
 		storageClass:     storageClass,
@@ -182,15 +197,16 @@ func pipe(ctx *cli.Context, targetURL string, encKeyDB map[string][]prefixSSEPai
 		checksum:         checksum,
 	}
 
-	var reader io.Reader
+	reader, streamSize, e := preparePipeReader(os.Stdin)
+	if e != nil {
+		return probe.NewError(e)
+	}
 	if !quiet && !json {
 		pg := newProgressBar(0)
-		reader = io.TeeReader(os.Stdin, pg)
-	} else {
-		reader = os.Stdin
+		reader = io.TeeReader(reader, pg)
 	}
 
-	n, err := putTargetStreamWithURL(targetURL, reader, -1, opts)
+	n, err := putTargetStreamWithURL(targetURL, reader, streamSize, opts)
 	// TODO: See if this check is necessary.
 	switch e := err.ToGoError().(type) {
 	case *os.PathError:

--- a/cmd/pipe-main_test.go
+++ b/cmd/pipe-main_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 PGSTY
+//
+// This file is part of the Silo object storage client.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package cmd
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"testing/iotest"
+)
+
+func TestPreparePipeReader(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		reader, size, err := preparePipeReader(strings.NewReader(""))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if size != 0 {
+			t.Fatalf("stream size = %d, want 0", size)
+		}
+		contents, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(contents) != 0 {
+			t.Fatalf("empty stream returned %d byte(s)", len(contents))
+		}
+	})
+
+	t.Run("non-empty", func(t *testing.T) {
+		reader, size, err := preparePipeReader(strings.NewReader("payload"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if size != -1 {
+			t.Fatalf("stream size = %d, want -1", size)
+		}
+		contents, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(contents) != "payload" {
+			t.Fatalf("stream contents = %q, want payload", contents)
+		}
+	})
+
+	t.Run("read error", func(t *testing.T) {
+		wantErr := errors.New("read failure")
+		_, _, err := preparePipeReader(iotest.ErrReader(wantErr))
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("preparePipeReader() error = %v, want %v", err, wantErr)
+		}
+	})
+}


### PR DESCRIPTION
## Summary\n\n- peek stdin once so an empty stream uses a known zero-length regular PUT\n- keep non-empty streams unknown-sized and byte-for-byte unchanged\n- change empty-pipe ETag from one-part multipart form to the standard empty-object MD5\n\n## Validation\n\n- full unit and full race from an isolated origin/main branch\n- focused pipe tests covering empty, non-empty and errors\n- real-S3 concurrent checksum pipe acceptance was completed on the original clean candidate\n\nNo release is triggered by this PR.