### PR TITLE
ci: make release retries tag-idempotent

### DIFF
--- a/.github/goreleaser.yml
+++ b/.github/goreleaser.yml
@@ -56,8 +56,10 @@ release:
     name: mc
   draft: true
   prerelease: false
-  mode: append
+  replace_existing_draft: true
   replace_existing_artifacts: false
+  mode: replace
+  # Draft replacement matches the release name; keep it identical to the tag.
   name_template: "{{ .Tag }}"
 
 changelog:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -55,6 +59,15 @@ jobs:
             echo "Invalid release tag format: ${TAG}"
             exit 1
           fi
+          if ! TAG_COMMIT="$(git rev-parse "${TAG}^{commit}" 2>/dev/null)"; then
+            echo "Release tag ${TAG} does not resolve to a commit" >&2
+            exit 1
+          fi
+          HEAD_COMMIT="$(git rev-parse HEAD)"
+          if [ "${TAG_COMMIT}" != "${HEAD_COMMIT}" ]; then
+            echo "Release tag ${TAG} resolves to ${TAG_COMMIT}, checkout is ${HEAD_COMMIT}" >&2
+            exit 1
+          fi
           VERSION_COLON="$(echo "${VERSION_HYPHEN}" | sed -E 's/T([0-9]{2})-([0-9]{2})-([0-9]{2})Z$/T\1:\2:\3Z/')"
           LDFLAGS="$(MC_RELEASE=RELEASE go run buildscripts/gen-ldflags.go "${VERSION_COLON}")"
 
@@ -68,6 +81,13 @@ jobs:
           echo "Package version: ${PKG_VERSION}"
           echo "LDFLAGS: ${LDFLAGS}"
 
+      - name: Check existing release state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          buildscripts/check-release-state.sh "${RELEASE_TAG}"
+
       - name: Build Draft release with GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
@@ -75,6 +95,7 @@ jobs:
           args: release --clean --skip=validate --config .github/goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ env.RELEASE_TAG }}
           LDFLAGS: ${{ env.LDFLAGS }}
           PKG_VERSION: ${{ env.PKG_VERSION }}
 
@@ -93,6 +114,14 @@ jobs:
         run: |
           set -euo pipefail
           buildscripts/package-release.sh
+
+      - name: Confirm Draft release state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUIRE_DRAFT: "true"
+        run: |
+          set -euo pipefail
+          buildscripts/check-release-state.sh "${RELEASE_TAG}"
 
       - name: Upload nFPM packages to Draft release
         env:

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -11,6 +11,8 @@ on:
       - "buildscripts/sign-release-rpms.sh"
       - "buildscripts/verify-rpm-payload.sh"
       - "buildscripts/verify-build-provenance.sh"
+      - "buildscripts/check-release-state.sh"
+      - "buildscripts/check-release-state_test.sh"
       - "buildscripts/gen-ldflags.go"
       - ".github/workflows/docker-release.yml"
       - ".github/workflows/release.yml"
@@ -234,7 +236,12 @@ jobs:
           bash -n buildscripts/sign-release-rpms.sh
           bash -n buildscripts/verify-rpm-payload.sh
           bash -n buildscripts/verify-build-provenance.sh
+          bash -n buildscripts/check-release-state.sh
+          bash -n buildscripts/check-release-state_test.sh
           test -x buildscripts/package-release.sh
           test -x buildscripts/sign-release-rpms.sh
           test -x buildscripts/verify-rpm-payload.sh
           test -x buildscripts/verify-build-provenance.sh
+          test -x buildscripts/check-release-state.sh
+          test -x buildscripts/check-release-state_test.sh
+          buildscripts/check-release-state_test.sh

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOLANGCI = $(GOPATH)/bin/golangci-lint
 GOLANGCI_VERSION ?= v2.13.1
 GOLANGCI_MODULE = github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
-.PHONY: credits check-credits check-dependency-floors
+.PHONY: credits check-credits check-dependency-floors test-release-state
 
 all: build
 
@@ -32,11 +32,15 @@ getdeps:
 crosscompile:
 	@(env bash $(PWD)/buildscripts/cross-compile.sh)
 
-verifiers: getdeps vet lint check-brand check-credits
+verifiers: getdeps vet lint check-brand check-credits test-release-state
 
 check-dependency-floors:
 	@echo "Checking dependency floors"
 	@go run ./buildscripts/check-dependency-floors
+
+test-release-state:
+	@echo "Checking release-state decisions"
+	@env bash $(PWD)/buildscripts/check-release-state_test.sh
 
 credits:
 	@env bash $(PWD)/buildscripts/gen-credits.sh

--- a/buildscripts/check-release-state.sh
+++ b/buildscripts/check-release-state.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Fail closed before a release job can replace published assets. Draft releases
+# are replaceable retry state; published releases are immutable.
+
+set -euo pipefail
+
+release_tag="${1:-}"
+fixture="${2:-}"
+repository="${GITHUB_REPOSITORY:-pgsty/mc}"
+require_draft="${REQUIRE_DRAFT:-false}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to inspect GitHub release state" >&2
+  exit 1
+fi
+
+if [[ ! "${release_tag}" =~ ^RELEASE\.[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z$ ]]; then
+  echo "Invalid release tag format: ${release_tag:-<empty>}" >&2
+  exit 1
+fi
+
+if [ -n "${fixture}" ]; then
+  release_json="$(cat "${fixture}")"
+else
+  error_file="$(mktemp)"
+  trap 'rm -f "${error_file}"' EXIT
+  if ! release_json="$(
+    gh api --paginate "repos/${repository}/releases?per_page=100" --jq '.[]' 2>"${error_file}" |
+      jq --arg tag "${release_tag}" -s '[.[] | select(.tag_name == $tag)]'
+  )"; then
+    cat "${error_file}" >&2
+    exit 1
+  fi
+fi
+
+if ! jq -e 'type == "array" and all(.[]; type == "object" and (.tag_name | type == "string") and (.draft | type == "boolean"))' \
+  <<<"${release_json}" >/dev/null 2>&1; then
+  echo "Invalid release state response for ${release_tag}" >&2
+  exit 1
+fi
+
+if ! jq -e --arg tag "${release_tag}" 'all(.[]; .tag_name == $tag)' \
+  <<<"${release_json}" >/dev/null 2>&1; then
+  echo "Release state returned a tag other than ${release_tag}" >&2
+  exit 1
+fi
+
+release_count="$(jq 'length' <<<"${release_json}")"
+if [ "${release_count}" -eq 0 ]; then
+  if [ "${require_draft}" = "true" ]; then
+    echo "Expected one Draft release for ${release_tag}, found none" >&2
+    exit 1
+  fi
+  echo "No existing release for ${release_tag}."
+  exit 0
+fi
+
+if [ "${release_count}" -ne 1 ]; then
+  echo "Refusing to choose among ${release_count} releases for ${release_tag}; clean duplicate Drafts first" >&2
+  exit 1
+fi
+
+if [ "$(jq -r '.[0].draft' <<<"${release_json}")" != "true" ]; then
+  echo "Refusing to overwrite published release ${release_tag}" >&2
+  exit 1
+fi
+
+echo "Existing Draft ${release_tag} will be replaced from scratch."

--- a/buildscripts/check-release-state_test.sh
+++ b/buildscripts/check-release-state_test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+checker="${script_dir}/check-release-state.sh"
+tag="RELEASE.2026-08-29T00-00-00Z"
+fixture="$(mktemp)"
+stdout_file="$(mktemp)"
+stderr_file="$(mktemp)"
+trap 'rm -f "${fixture}" "${stdout_file}" "${stderr_file}"' EXIT
+
+expect_success() {
+  if ! "${checker}" "$@" >"${stdout_file}" 2>"${stderr_file}"; then
+    cat "${stderr_file}" >&2
+    return 1
+  fi
+}
+
+expect_failure() {
+  if "${checker}" "$@" >"${stdout_file}" 2>"${stderr_file}"; then
+    echo "Expected release-state check to fail: $*" >&2
+    return 1
+  fi
+}
+
+printf '[]\n' >"${fixture}"
+expect_success "${tag}" "${fixture}"
+grep -qF "No existing release for ${tag}." "${stdout_file}"
+
+if REQUIRE_DRAFT=true "${checker}" "${tag}" "${fixture}" >"${stdout_file}" 2>"${stderr_file}"; then
+  echo "Expected required-Draft check to fail when no release exists" >&2
+  exit 1
+fi
+grep -qF "Expected one Draft release for ${tag}, found none" "${stderr_file}"
+
+printf '[{"tag_name":"%s","draft":true}]\n' "${tag}" >"${fixture}"
+expect_success "${tag}" "${fixture}"
+grep -qF "Existing Draft ${tag} will be replaced from scratch." "${stdout_file}"
+if ! REQUIRE_DRAFT=true "${checker}" "${tag}" "${fixture}" >"${stdout_file}" 2>"${stderr_file}"; then
+  cat "${stderr_file}" >&2
+  exit 1
+fi
+grep -qF "Existing Draft ${tag} will be replaced from scratch." "${stdout_file}"
+
+printf '[{"tag_name":"%s","draft":false}]\n' "${tag}" >"${fixture}"
+expect_failure "${tag}" "${fixture}"
+grep -qF "Refusing to overwrite published release ${tag}" "${stderr_file}"
+if REQUIRE_DRAFT=true "${checker}" "${tag}" "${fixture}" >"${stdout_file}" 2>"${stderr_file}"; then
+  echo "Expected required-Draft check to reject a published release" >&2
+  exit 1
+fi
+grep -qF "Refusing to overwrite published release ${tag}" "${stderr_file}"
+
+printf '[{"tag_name":"%s","draft":true},{"tag_name":"%s","draft":true}]\n' "${tag}" "${tag}" >"${fixture}"
+expect_failure "${tag}" "${fixture}"
+grep -qF "Refusing to choose among 2 releases" "${stderr_file}"
+
+printf '[{"tag_name":"RELEASE.2026-08-28T00-00-00Z","draft":true}]\n' >"${fixture}"
+expect_failure "${tag}" "${fixture}"
+grep -qF "other than ${tag}" "${stderr_file}"
+
+printf '{not-json}\n' >"${fixture}"
+expect_failure "${tag}" "${fixture}"
+grep -qF "Invalid release state response for ${tag}" "${stderr_file}"
+
+expect_failure "not-a-release-tag" "${fixture}"
+grep -qF "Invalid release tag format" "${stderr_file}"
+
+echo "release-state decision tests passed"


### PR DESCRIPTION
## Summary\n\n- serialize Release jobs by resolved tag\n- validate tag-to-checkout identity and pin GoReleaser to that tag\n- refuse published, duplicate or inaccessible release state\n- replace exactly one Draft from scratch and re-confirm it before package upload\n- add fail-closed fixture tests to the Test Release Pipeline\n\n## Validation\n\n- release-state fixture suite\n- actionlint v1.7.12 across all workflows\n- GoReleaser config validation\n- full unit tests\n\nRefs #6. This PR does not run Release/Test Release, create a tag, or publish assets.