### PR TITLE
fix: read the applied globals for pipe's quiet and json flags

### DIFF
--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -238,10 +238,11 @@ func mainPipe(ctx *cli.Context) error {
 	encKeyDB, err := validateAndCreateEncryptionKeys(ctx)
 	fatalIf(err, "Unable to parse encryption keys.")
 
-	// globalQuiet is true for no window size to get.
-	// We just need --quiet and --json here.
-	quiet := ctx.Bool("quiet")
-	json := ctx.Bool("json")
+	// The applied globals already merge --quiet and --json from both flag
+	// positions, and raise quiet when stdout has no window size. Reading them
+	// keeps the progress bar out of a redirected stdout, the way every other
+	// transfer command behaves.
+	quiet, json := globalQuiet, globalJSON
 
 	meta := map[string]string{}
 	if attr := ctx.String("attr"); attr != "" {

--- a/cmd/pipe-output_test.go
+++ b/cmd/pipe-output_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 PGSTY
+//
+// This file is part of the Silo object storage client.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// runPipeCLI streams stdin into a real mcli subprocess whose stdout is a pipe,
+// which is what a redirect or a shell pipeline looks like to the process. It
+// reuses the checksum verify CLI harness, so the child runs Main with a clean
+// MC_* environment; the endpoint is never contacted because the target is a
+// local path.
+func runPipeCLI(t *testing.T, stdin io.Reader, args ...string) checksumVerifyCLIResult {
+	t.Helper()
+	command := checksumVerifyCLICommand(t, "http://127.0.0.1:1", nil, args...)
+	command.Stdin = stdin
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	exitCode := checksumVerifyCLIExitCode(t, command)
+	return checksumVerifyCLIResult{stdout: stdout.Bytes(), stderr: stderr.Bytes(), exitCode: exitCode}
+}
+
+// trickleReader hands out its payload a few bytes at a time with a pause in
+// between, so the progress bar has time to redraw during the upload. Without
+// it a local target finishes inside one refresh interval and the absence of
+// bar frames would prove nothing.
+type trickleReader struct {
+	chunks [][]byte
+	pause  time.Duration
+}
+
+func (r *trickleReader) Read(p []byte) (int, error) {
+	if len(r.chunks) == 0 {
+		return 0, io.EOF
+	}
+	time.Sleep(r.pause)
+	n := copy(p, r.chunks[0])
+	r.chunks = r.chunks[1:]
+	return n, nil
+}
+
+// TestPipeOutputContract pins what `mcli pipe` writes to a stdout that is not
+// a terminal: the summary, in the form the flags ask for, and nothing else.
+// Progress redraws belong to the terminal UI and must not reach a captured
+// stream, which is the rule pgsty/mc#5 settled for this global.
+func TestPipeOutputContract(t *testing.T) {
+	const payload = "silo pipe output contract"
+
+	// Main raises quiet for a stdout with no window size on every platform but
+	// Windows, so only there does a run without an explicit flag depend on it.
+	autoQuiet := runtime.GOOS != "windows"
+
+	for _, tc := range []struct {
+		name     string
+		appFlags []string
+		cmdFlags []string
+		wantJSON bool
+		wantText bool
+		explicit bool // a flag suppresses the bar without help from auto-quiet
+	}{
+		{name: "no flags", wantText: true},
+		{name: "json before command", appFlags: []string{"--json"}, wantJSON: true, explicit: true},
+		{name: "json after command", cmdFlags: []string{"--json"}, wantJSON: true, explicit: true},
+		{name: "quiet before command", appFlags: []string{"--quiet"}, wantText: true, explicit: true},
+		{name: "quiet after command", cmdFlags: []string{"--quiet"}, wantText: true, explicit: true},
+		{name: "explicit json false", cmdFlags: []string{"--json=false"}, wantText: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			target := filepath.Join(t.TempDir(), "object")
+			args := append([]string{}, tc.appFlags...)
+			args = append(args, "pipe")
+			args = append(args, tc.cmdFlags...)
+			args = append(args, target)
+
+			result := runPipeCLI(t, strings.NewReader(payload), args...)
+			if result.exitCode != 0 {
+				t.Fatalf("exit code %d, want 0; stderr=%s", result.exitCode, result.stderr)
+			}
+			if got, e := os.ReadFile(target); e != nil || string(got) != payload {
+				t.Fatalf("target = %q, %v; want %q", got, e, payload)
+			}
+			if (tc.explicit || autoQuiet) && bytes.ContainsRune(result.stdout, '\r') {
+				t.Fatalf("progress redraw reached a captured stdout: %q", result.stdout)
+			}
+			switch {
+			case tc.wantJSON:
+				var msg pipeMessage
+				if e := json.Unmarshal(bytes.TrimSpace(result.stdout), &msg); e != nil {
+					t.Fatalf("stdout is not one JSON document: %v in %q", e, result.stdout)
+				}
+				if msg.Status != "success" || msg.Size != int64(len(payload)) {
+					t.Fatalf("JSON summary = %+v, want success and %d bytes", msg, len(payload))
+				}
+			case tc.wantText:
+				if !strings.Contains(string(result.stdout), "bytes -> ") {
+					t.Fatalf("stdout %q does not carry the human summary", result.stdout)
+				}
+			}
+		})
+	}
+
+	t.Run("no redraw during a slow upload", func(t *testing.T) {
+		if !autoQuiet {
+			t.Skip("Main does not raise auto-quiet on this platform, so the bar is expected here")
+		}
+		target := filepath.Join(t.TempDir(), "object")
+		stdin := &trickleReader{
+			chunks: [][]byte{[]byte("aaaa"), []byte("bbbb"), []byte("cccc")},
+			pause:  400 * time.Millisecond,
+		}
+		result := runPipeCLI(t, stdin, "pipe", target)
+		if result.exitCode != 0 {
+			t.Fatalf("exit code %d, want 0; stderr=%s", result.exitCode, result.stderr)
+		}
+		if n := bytes.Count(result.stdout, []byte{'\r'}); n != 0 {
+			t.Fatalf("%d progress redraws reached a captured stdout: %q", n, result.stdout)
+		}
+		if got, e := os.ReadFile(target); e != nil || string(got) != "aaaabbbbcccc" {
+			t.Fatalf("target = %q, %v", got, e)
+		}
+	})
+}


### PR DESCRIPTION
## Contribution Licensing (no CLA, inbound=outbound, DCO required)
This project does not use a CLA; contributions are accepted inbound=outbound.
All community contributions in this pull request are licensed under the
[GNU AGPL v3.0 or later](https://www.gnu.org/licenses/agpl-3.0.html), the
license of this project, and every commit carries a DCO `Signed-off-by` trailer.

## Description

`mainPipe` read only the command-level `ctx.Bool("quiet")` / `ctx.Bool("json")`, so `--json` or `--quiet` given before `pipe` were ignored for the progress bar while the final message honoured the applied globals (a `\r 0 B / ? ` prefix on the JSON document, #29), and `pipe` was the only transfer command gating its bar on the raw flag instead of `globalQuiet`, so it wrote carriage-return frames into a redirected stdout unlike `cp`, `put`, `get` and `mirror` (#30). `mainPipe` now reads `quiet, json := globalQuiet, globalJSON`, which `applyGlobalsFromContext` merges from both flag positions and which `Main` raises when stdout has no window size. Two product lines.

Fixes #29. Fixes #30. Plan: https://github.com/pgsty/mc/issues/29#issuecomment-5549418622 as amended by https://github.com/pgsty/mc/issues/29#issuecomment-5549779954 (the helper approach was superseded by this two-line change), and the #30 issue body. Adversarial Codex review of this implementation: round 1 PASS with no findings.

## Motivation and Context

Both flag positions are documented, and the auto-raised `globalQuiet` exists precisely to keep progress UI out of a captured stdout (pgsty/mc#5 settled that rule). Inherited from upstream `mc` (`ffa7a67b`, `65aa514d`).

## How to test

```
GOWORK=off go test ./cmd -run '^(TestPipeOutputContract|TestPreparePipeReader|TestPipeChannel)$' -count=1 -v
```

`TestPipeOutputContract` re-execs the test binary as `mcli pipe` against a local filesystem target with stdout captured and asserts exit status, payload, summary shape, JSON validity and the absence of carriage returns for both flag positions plus `--json=false`; the flag-free cases assert the absence of frames only where `Main` raises auto-quiet, so the Windows job stays green. Five of seven cases fail on main, all seven pass with the fix. Measured with binaries built from main: `pipe T > out` goes from 379 bytes / 16 CR frames to 125 bytes / 0 frames for a two-second upload; with stdout on a sized pseudo-terminal the output is byte-identical.

## Compatibility impact

CLI output selection only; no wire, API or config change. `mcli --json pipe` and `mcli --quiet pipe` now behave like their after-command forms; `mcli pipe T > out` and `| cat` no longer contain progress frames; the one behaviour loss is no live bar under `| tee`, which is how `cp` and `mirror` already behave. Windows keeps its current flag-free redirect behaviour because `Main` does not raise auto-quiet there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7qJqWwy8oFA6aCXWRzXQe
