### PR TITLE
fix: accept on/off and enabled/disabled in MC_* boolean env vars

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -113,6 +113,12 @@ func Main(args []string) error {
 		}
 	}
 
+	// Normalize the boolean environment variables before anything reads
+	// them, the CLI library included.
+	if e := normalizeBoolEnvVars(append(mcFlags, globalFlags...)); e != nil {
+		return e
+	}
+
 	probe.Init() // Set project's root source path.
 	probe.SetAppInfo("Release-Tag", ReleaseTag)
 	probe.SetAppInfo("Commit", ShortCommitID)
@@ -142,6 +148,60 @@ func Main(args []string) error {
 	parsePagerDisableFlag(args)
 	// Run the app
 	return registerApp(appName).Run(args)
+}
+
+// mcBoolEnvSynonyms are the boolean spellings mc accepts in its environment
+// variables on top of the ones strconv.ParseBool understands. They are the
+// extra words the SILO server accepts for the same kind of switch, matched
+// case insensitively, so one vocabulary covers both sides.
+var mcBoolEnvSynonyms = map[string]string{
+	"on":       "true",
+	"off":      "false",
+	"enabled":  "true",
+	"disabled": "false",
+}
+
+// normalizeBoolEnvVars rewrites the environment variables that back boolean
+// flags so the CLI library sees a literal it can parse. Without this pass the
+// library aborts the process for any other value, with a message that names
+// the flag instead of the variable that carries the value. Values the library
+// already accepts are left untouched, and the first variable that is present
+// wins, both to match BoolFlag.ApplyWithError.
+func normalizeBoolEnvVars(flags []cli.Flag) error {
+	for _, f := range flags {
+		bf, ok := f.(cli.BoolFlag)
+		if !ok || bf.EnvVar == "" {
+			continue
+		}
+		for _, name := range strings.Split(bf.EnvVar, ",") {
+			name = strings.TrimSpace(name)
+			value, isSet := os.LookupEnv(name)
+			if !isSet {
+				continue
+			}
+			if err := normalizeBoolEnvVar(name, value); err != nil {
+				return err
+			}
+			break
+		}
+	}
+	return nil
+}
+
+// normalizeBoolEnvVar rewrites one variable in place. An empty value already
+// means false to the CLI library, so it is left alone.
+func normalizeBoolEnvVar(name, value string) error {
+	if value == "" {
+		return nil
+	}
+	if _, e := strconv.ParseBool(value); e == nil {
+		return nil
+	}
+	normalized, known := mcBoolEnvSynonyms[strings.ToLower(value)]
+	if !known {
+		return fmt.Errorf("%s is set to %q, which is not a boolean; use true/false, t/f, 1/0, on/off or enabled/disabled", name, value)
+	}
+	return os.Setenv(name, normalized)
 }
 
 func flagValue(f cli.Flag) reflect.Value {

--- a/cmd/main_boolenv_test.go
+++ b/cmd/main_boolenv_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 PGSTY
+//
+// This file is part of the Silo object storage client.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/minio/cli"
+)
+
+// neutralizeBoolEnvVars empties every variable the pass inspects, so an
+// inherited setting can neither fail the run before the case under test is
+// reached nor be rewritten outside the test's own cleanup. An empty value is
+// the one the CLI library already reads as false.
+func neutralizeBoolEnvVars(t *testing.T, flags []cli.Flag) {
+	t.Helper()
+	for _, f := range flags {
+		bf, ok := f.(cli.BoolFlag)
+		if !ok || bf.EnvVar == "" {
+			continue
+		}
+		for _, name := range strings.Split(bf.EnvVar, ",") {
+			t.Setenv(strings.TrimSpace(name), "")
+		}
+	}
+}
+
+// TestNormalizeBoolEnvVars checks the three classes of value: the literals
+// strconv.ParseBool already accepts are left byte for byte alone, the SILO
+// boolean spellings are rewritten into those literals, and anything else is
+// reported against the variable that carries it. The production flag list is
+// used so a boolean flag added later is covered without touching this test.
+func TestNormalizeBoolEnvVars(t *testing.T) {
+	flags := append(mcFlags, globalFlags...)
+	neutralizeBoolEnvVars(t, flags)
+
+	for _, tc := range []struct {
+		value string
+		want  string // "" means the call must fail
+	}{
+		{value: "true", want: "true"},
+		{value: "false", want: "false"},
+		{value: "1", want: "1"},
+		{value: "0", want: "0"},
+		{value: "T", want: "T"},
+		{value: "on", want: "true"},
+		{value: "ON", want: "true"},
+		{value: "On", want: "true"},
+		{value: "off", want: "false"},
+		{value: "OFF", want: "false"},
+		{value: "enabled", want: "true"},
+		{value: "Disabled", want: "false"},
+		{value: " on ", want: ""},
+		{value: " true ", want: ""},
+		{value: "yes", want: ""},
+		{value: "no", want: ""},
+		{value: "bogus", want: ""},
+	} {
+		t.Run(tc.value, func(t *testing.T) {
+			t.Setenv(envPrefix+"JSON", tc.value)
+
+			err := normalizeBoolEnvVars(flags)
+			if tc.want == "" {
+				if err == nil {
+					t.Fatalf("%s=%q was accepted, want an error", envPrefix+"JSON", tc.value)
+				}
+				if !strings.Contains(err.Error(), envPrefix+"JSON") {
+					t.Errorf("error %q does not name %s", err, envPrefix+"JSON")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("%s=%q: %v", envPrefix+"JSON", tc.value, err)
+			}
+			if got := os.Getenv(envPrefix + "JSON"); got != tc.want {
+				t.Fatalf("%s = %q, want %q", envPrefix+"JSON", got, tc.want)
+			}
+			// Whatever is left must be something the CLI library can parse,
+			// which is the only reason this pass exists.
+			if _, e := strconv.ParseBool(os.Getenv(envPrefix + "JSON")); e != nil {
+				t.Fatalf("normalized value is still unparseable: %v", e)
+			}
+		})
+	}
+
+	t.Run("every bool flag with an env var is covered", func(t *testing.T) {
+		neutralizeBoolEnvVars(t, flags)
+		for _, f := range flags {
+			bf, ok := f.(cli.BoolFlag)
+			if !ok || bf.EnvVar == "" {
+				continue
+			}
+			for _, name := range strings.Split(bf.EnvVar, ",") {
+				name = strings.TrimSpace(name)
+				t.Setenv(name, "on")
+				if err := normalizeBoolEnvVars(flags); err != nil {
+					t.Fatalf("%s=on: %v", name, err)
+				}
+				if got := os.Getenv(name); got != "true" {
+					t.Errorf("%s = %q, want \"true\"", name, got)
+				}
+			}
+		}
+	})
+
+	t.Run("unset and empty are untouched", func(t *testing.T) {
+		neutralizeBoolEnvVars(t, flags)
+		t.Setenv(envPrefix+"JSON", "")
+		if err := normalizeBoolEnvVars(flags); err != nil {
+			t.Fatalf("empty value: %v", err)
+		}
+		if got, ok := os.LookupEnv(envPrefix + "JSON"); !ok || got != "" {
+			t.Errorf("%s = %q %v, want empty and set", envPrefix+"JSON", got, ok)
+		}
+	})
+}


### PR DESCRIPTION
## Contribution Licensing (no CLA, inbound=outbound, DCO required)
This project does not use a CLA; contributions are accepted inbound=outbound.
All community contributions in this pull request are licensed under the
[GNU AGPL v3.0 or later](https://www.gnu.org/licenses/agpl-3.0.html), the
license of this project, and every commit carries a DCO `Signed-off-by` trailer.

## Description

The six `MC_*` boolean environment variables (`MC_QUIET`, `MC_JSON`, `MC_DEBUG`, `MC_NO_COLOR`, `MC_INSECURE`, `MC_DISABLE_PAGER`) were parsed with `strconv.ParseBool` only, so `MC_JSON=on` or `MC_QUIET=off` aborted every mcli invocation, `--help` and `--version` included, with a message naming a flag the user never typed. A `normalizeBoolEnvVars` pre-pass in `Main`, before `probe.Init` and driven off the production flag list, rewrites `on/off/enabled/disabled` (case-insensitively, no trimming) to `true/false`, leaves values the library already accepts untouched, honours the first present variable like `BoolFlag.ApplyWithError`, and reports anything else with a message that names the variable and the accepted literals.

Fixes #31. The issue body is the plan agreed with the Codex reviewer (3 rounds). Adversarial Codex review of this implementation: round 1 PASS (one optional NIT on a subtest name).

## Motivation and Context

The SILO server accepts `on/off` and `enabled/disabled` for the same kind of switch; a shell profile or container environment using those spellings should not disable the CLI entirely. Inherited from upstream `mc` (`062f28c9` added the environment names; `github.com/minio/cli` is unmodified).

## How to test

```
GOWORK=off go test ./cmd -run '^TestNormalizeBoolEnvVars' -count=1 -v
MC_JSON=on ./mcli --version; MC_JSON=off ./mcli --version; MC_JSON=bogus ./mcli --version; MC_JSON=true ./mcli --version
```

The table-driven test covers accepted, rewritten and rejected values across the full production flag list, clears every inspected variable first and passes under an inherited `MC_JSON=on MC_DEBUG=bogus` environment. With the built binary, `on`/`off`/`enabled`/`disabled` now work, `bogus` exits 1 naming `MC_JSON`, and `true`/`1`/`0`/empty keep their meaning.

## Compatibility impact

Widens only the environment-variable vocabulary; command-line `--json=off` remains a Go flag-package error as before. No wire, API or config-file change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7qJqWwy8oFA6aCXWRzXQe
