### PR TITLE
fix: sql exits non-zero when a query fails

### DIFF
--- a/cmd/sql-main.go
+++ b/cmd/sql-main.go
@@ -441,6 +441,7 @@ func mainSQL(cliCtx *cli.Context) error {
 		csvHdrs []string
 		selOpts SelectObjectOpts
 		query   string
+		cErr    error
 	)
 	// Parse encryption keys per command.
 	encKeyDB, err := validateAndCreateEncryptionKeys(cliCtx)
@@ -454,12 +455,16 @@ func mainSQL(cliCtx *cli.Context) error {
 	for _, url := range URLs {
 		if _, targetContent, err := url2Stat(ctx, url2StatOptions{urlStr: url, versionID: "", fileAttr: false, encKeyDB: encKeyDB, timeRef: time.Time{}, isZip: false, ignoreBucketExistsCheck: false}); err != nil {
 			errorIf(err.Trace(url), "Unable to run sql for %s.", url)
+			cErr = exitStatus(globalErrorExitStatus) // Set the exit status.
 			continue
 		} else if !targetContent.Type.IsDir() {
 			if writeHdr {
 				query, csvHdrs, selOpts = getAndValidateArgs(cliCtx, encKeyDB, url)
 			}
-			errorIf(sqlSelect(url, query, encKeyDB, selOpts, csvHdrs, writeHdr).Trace(url), "Unable to run sql")
+			if sqlErr := sqlSelect(url, query, encKeyDB, selOpts, csvHdrs, writeHdr); sqlErr != nil {
+				errorIf(sqlErr.Trace(url), "Unable to run sql")
+				cErr = exitStatus(globalErrorExitStatus) // Set the exit status.
+			}
 			writeHdr = false
 			continue
 		}
@@ -467,12 +472,14 @@ func mainSQL(cliCtx *cli.Context) error {
 		clnt, err := newClientFromAlias(targetAlias, targetURL)
 		if err != nil {
 			errorIf(err.Trace(url), "Unable to initialize target `%s`.", url)
+			cErr = exitStatus(globalErrorExitStatus) // Set the exit status.
 			continue
 		}
 
 		for content := range clnt.List(ctx, ListOptions{Recursive: cliCtx.Bool("recursive"), WithMetadata: true, ShowDir: DirNone}) {
 			if content.Err != nil {
 				errorIf(content.Err.Trace(url), "Unable to list on target `%s`.", url)
+				cErr = exitStatus(globalErrorExitStatus) // Set the exit status.
 				continue
 			}
 			if writeHdr {
@@ -484,8 +491,11 @@ func mainSQL(cliCtx *cli.Context) error {
 			}
 			for _, cTypeSuffix := range supportedContentTypes {
 				if strings.Contains(contentType, cTypeSuffix) {
-					errorIf(sqlSelect(targetAlias+content.URL.Path, query,
-						encKeyDB, selOpts, csvHdrs, writeHdr).Trace(content.URL.String()), "Unable to run sql")
+					if sqlErr := sqlSelect(targetAlias+content.URL.Path, query,
+						encKeyDB, selOpts, csvHdrs, writeHdr); sqlErr != nil {
+						errorIf(sqlErr.Trace(content.URL.String()), "Unable to run sql")
+						cErr = exitStatus(globalErrorExitStatus) // Set the exit status.
+					}
 				}
 				writeHdr = false
 			}
@@ -493,5 +503,5 @@ func mainSQL(cliCtx *cli.Context) error {
 	}
 
 	// Done.
-	return nil
+	return cErr
 }

--- a/cmd/sql-main_test.go
+++ b/cmd/sql-main_test.go
@@ -18,8 +18,17 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/pgsty/silo-pkg/v3/console"
 )
 
 var testParseKVArgsCases = []struct {
@@ -145,5 +154,100 @@ func TestParseSerializationOpts(t *testing.T) {
 				t.Fatalf("Test %d:Unexpected result for \"%s,\" expected %s , found %s for key %s\n", i+1, test.inp, v, actual, k)
 			}
 		}
+	}
+}
+
+const sqlCLIHelperEnv = "MC_SQL_CLI_HELPER"
+
+// TestSQLCLIHelper is re-executed as a child process by TestSQLExitStatus. It
+// runs the real mcli entry point (Main) so that a failing `sql` run exits with
+// the process code the CLI would use in production, mirroring package main's
+// `if err := mc.Main(os.Args); err != nil { console.Fatalln(err) }`.
+func TestSQLCLIHelper(_ *testing.T) {
+	if os.Getenv(sqlCLIHelperEnv) != "1" {
+		return
+	}
+	separator := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator < 0 {
+		console.Fatalln("sql CLI helper is missing --")
+	}
+	args := append([]string{"mcli"}, os.Args[separator+1:]...)
+	if err := Main(args); err != nil {
+		console.Fatalln(err)
+	}
+	os.Exit(0)
+}
+
+// runSQLCLI runs `mcli <args...>` in an isolated child process against a
+// throwaway config directory and returns its exit code.
+func runSQLCLI(t *testing.T, args ...string) int {
+	t.Helper()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	configDir := t.TempDir()
+	if err = os.WriteFile(filepath.Join(configDir, globalMCConfigFile), []byte("{\"version\":\"10\",\"aliases\":{}}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err = os.MkdirAll(filepath.Join(configDir, globalSharedURLsDataDir), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	helperArgs := append([]string{"-test.run=^TestSQLCLIHelper$", "--"}, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	t.Cleanup(cancel)
+	command := exec.CommandContext(ctx, executable, helperArgs...)
+	command.Args[0] = "mcli"
+
+	// Strip inherited MC_* configuration so the child only sees the temp
+	// config directory created above.
+	childEnv := make([]string, 0, len(os.Environ())+2)
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(strings.ToUpper(key), "MC_") {
+			continue
+		}
+		childEnv = append(childEnv, entry)
+	}
+	command.Env = append(childEnv, sqlCLIHelperEnv+"=1", "MC_CONFIG_DIR="+configDir)
+
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	command.Stdout = &bytes.Buffer{}
+	if err = command.Run(); err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("running sql CLI helper: %v (stderr: %s)", err, stderr.String())
+	}
+	return exitErr.ExitCode()
+}
+
+// TestSQLExitStatus is the regression test for issue #25: `mc sql` reported a
+// per-object failure through errorIf but always exited 0, so scripts could not
+// detect failure. A failing target must now yield a non-zero exit status while
+// a run with nothing to fail on still exits 0.
+func TestSQLExitStatus(t *testing.T) {
+	// A nonexistent local target fails in url2Stat and is reported through the
+	// same errorIf/accumulate path that a bad query in sqlSelect takes; no
+	// live server is required to exercise the failure exit status.
+	badTarget := filepath.Join(t.TempDir(), "does-not-exist.csv")
+	if code := runSQLCLI(t, "sql", "--query", "select * from s3object", badTarget); code == 0 {
+		t.Fatalf("mc sql on a failing target exited 0, want non-zero (issue #25)")
+	}
+
+	// A recursive run over an empty directory has no object to fail on and
+	// must still exit 0, guarding against a false-positive exit status.
+	emptyDir := t.TempDir()
+	if code := runSQLCLI(t, "sql", "--recursive", "--query", "select * from s3object", emptyDir+"/"); code != 0 {
+		t.Fatalf("mc sql over an empty directory exited %d, want 0", code)
 	}
 }


### PR DESCRIPTION
## Description

Fixes #25. `mcli sql --query <bad> ALIAS/BUCKET/obj` printed a query error to stderr but exited `0`, so automation checking the exit code could not tell a failed query from an empty result.

`mainSQL` reported every per-object failure through `errorIf` (logs only, no effect on exit) and always `return nil`. It now accumulates a non-zero exit status on failure and returns it, matching the established codebase idiom for "continue past a bad object but exit non-zero".

## Fix (`cmd/sql-main.go`, minimal)

- Add a `cErr error` accumulator; set `cErr = exitStatus(globalErrorExitStatus)` at each of the 5 failure sites (`url2Stat`, single-object `sqlSelect`, `newClientFromAlias`, list `content.Err`, recursive `sqlSelect`); `return cErr` instead of `return nil`.
- The two inline `errorIf(sqlSelect(...).Trace(...), ...)` sites capture the `*probe.Error` first and only call `errorIf` when non-nil, so the stderr error message is byte-identical (a successful `sqlSelect` returns `probe.NewError(nil) == nil`, and `errorIf`/`Trace` no-op on nil).
- `--recursive` still `continue`s past one bad object; success still exits 0.

This mirrors `ls.go:240`, `stat.go:322`, and `rm-main.go`; no change to `errorIf` or any shared infrastructure.

## Note on stderr

A failed `sql` now skips the deferred `app.After` cert-expiry warning — because returning an `ExitCoder` triggers `HandleExitCoder → os.Exit` before the deferred hook, identically to every other command that fails (`ls`/`stat`/`rm`/…). That warning previously appeared on a failed query only because of this bug (the query wrongly returned exit 0). The SQL error message format is unchanged.

## Adversarial review

Codex Astra 6 (Max), 2 rounds → **VERDICT PASS**. Round 1 raised the `app.After` skip; round 2 agreed it is the uniform, correct behavior for the `exitStatus` idiom and withdrew the finding.

## How to test

```
go test -tags kqueue ./cmd -run '^TestSQLExitStatus$'
```

`TestSQLExitStatus` runs the real `Main` in a child process (no live server), asserting a failing target exits non-zero and an empty recursive run exits 0. Red-on-revert: reverting to `return nil` makes it fail ("exited 0, want non-zero"). `go build`/`go vet`/`gofmt` clean; full `./cmd` package tests pass.

## Types of changes
- [x] Bug fix (non-breaking)

## Checklist
- [x] Signed off; build/vet/gofmt clean; package tests pass
- [x] Adversarial Codex review PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7qJqWwy8oFA6aCXWRzXQe