### PR TITLE
Fix mirror deletion, transfer error exits, and noninteractive restarts

### DIFF
--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -267,7 +267,7 @@ func mainAdminServiceRestart(ctx *cli.Context) error {
 			Action: madmin.ServiceActionRestart,
 			DryRun: ctx.Bool("dry-run"),
 		})
-		if e != nil {
+		if e != nil && !ctx.Bool("dry-run") {
 			// Attempt an older API server might be old
 			// nolint:staticcheck
 			// we need this fallback

--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -28,6 +29,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/fatih/color"
+	"github.com/mattn/go-isatty"
 	"github.com/minio/cli"
 	json "github.com/minio/colorjson"
 	"github.com/minio/madmin-go/v3"
@@ -212,7 +214,27 @@ type serviceRestartMessage struct {
 }
 
 func (s serviceRestartMessage) String() string {
-	return s.JSON()
+	action := "Restart request sent to"
+	if s.Result.DryRun {
+		action = "Dry run completed for"
+	}
+	summary := fmt.Sprintf("%s %s", action, s.ServerURL)
+	if total := len(s.Result.Results); total > 0 {
+		var offline, hung int
+		for _, peer := range s.Result.Results {
+			if peer.Err != "" {
+				offline++
+			} else if len(peer.WaitingDrives) > 0 {
+				hung++
+			}
+		}
+		summary += fmt.Sprintf(": %d online, %d offline, %d hung", total-offline-hung, offline, hung)
+	}
+	summary += fmt.Sprintf("; request time %s", s.RestartDuration)
+	if s.WaitingDuration > 0 {
+		summary += fmt.Sprintf("; initialization wait %s", s.WaitingDuration)
+	}
+	return summary
 }
 
 // JSON jsonified service restart command message.
@@ -256,9 +278,9 @@ func mainAdminServiceRestart(ctx *cli.Context) error {
 		rowCount = 3
 	}
 
-	ch := make(chan serviceRestartMessage, 1)
+	useUI := !globalJSON && !globalQuiet && isTerminal() && isatty.IsTerminal(os.Stdin.Fd())
 
-	svcUI := initServiceRestartUI(rowCount, ch)
+	ch := make(chan serviceRestartMessage, 1)
 	go func() {
 		t := time.Now()
 
@@ -340,7 +362,8 @@ func mainAdminServiceRestart(ctx *cli.Context) error {
 		}
 	}()
 
-	if !globalJSON {
+	if useUI {
+		svcUI := initServiceRestartUI(rowCount, ch)
 		ui := tea.NewProgram(svcUI)
 		if _, e := ui.Run(); e != nil {
 			cancel()
@@ -348,7 +371,9 @@ func mainAdminServiceRestart(ctx *cli.Context) error {
 		}
 	} else {
 		for msg := range ch {
-			printMsg(msg)
+			if globalJSON || msg.State == done {
+				printMsg(msg)
+			}
 			if msg.State == done {
 				break
 			}

--- a/cmd/admin-service-restart_test.go
+++ b/cmd/admin-service-restart_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 PGSTY
+//
+// This file is part of the Silo object storage client.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestServiceRestartDryRunNeverFallsBack(t *testing.T) {
+	for _, dryRun := range []bool{true, false} {
+		t.Run(fmt.Sprintf("dry-run=%t", dryRun), func(t *testing.T) {
+			var modern, legacy atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != "/minio/admin/v3/service" || r.URL.Query().Get("action") != "restart" {
+					t.Errorf("unexpected request %s %s", r.Method, r.URL)
+					http.NotFound(w, r)
+					return
+				}
+				if r.URL.Query().Get("type") == "2" {
+					modern.Add(1)
+					if r.URL.Query().Get("dry-run") != fmt.Sprint(dryRun) {
+						t.Errorf("wrong dry-run: %s", r.URL)
+					}
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusForbidden)
+					_, _ = io.WriteString(w, `{"Code":"AccessDenied","Message":"fixture rejects service action"}`)
+				} else {
+					legacy.Add(1)
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+			args := []string{"--json", "admin", "service", "restart"}
+			if dryRun {
+				args = append(args, "--dry-run")
+			}
+			result := runChecksumVerifyCLI(t, server.URL, nil, append(args, "b4")...)
+			wantExit, wantLegacy := 0, int32(1)
+			if dryRun {
+				wantExit, wantLegacy = 1, 0
+			}
+			if result.exitCode != wantExit || modern.Load() != 1 || legacy.Load() != wantLegacy {
+				t.Fatalf("exit=%d modern=%d legacy=%d, want exit=%d legacy=%d; stdout=%s stderr=%s", result.exitCode, modern.Load(), legacy.Load(), wantExit, wantLegacy, result.stdout, result.stderr)
+			}
+		})
+	}
+}

--- a/cmd/admin-service-restart_test.go
+++ b/cmd/admin-service-restart_test.go
@@ -18,12 +18,16 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+
+	"github.com/minio/madmin-go/v3"
 )
 
 func TestServiceRestartDryRunNeverFallsBack(t *testing.T) {
@@ -63,5 +67,81 @@ func TestServiceRestartDryRunNeverFallsBack(t *testing.T) {
 				t.Fatalf("exit=%d modern=%d legacy=%d, want exit=%d legacy=%d; stdout=%s stderr=%s", result.exitCode, modern.Load(), legacy.Load(), wantExit, wantLegacy, result.stdout, result.stderr)
 			}
 		})
+	}
+}
+
+func newServiceRestartTestServer(t *testing.T, unhealthy bool) *httptest.Server {
+	t.Helper()
+	var healthCalls atomic.Int32
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/minio/admin/v3/service":
+			if r.URL.Query().Get("type") != "2" || r.URL.Query().Get("action") != "restart" {
+				t.Errorf("unexpected restart request: %s", r.URL)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(madmin.ServiceActionResult{
+				Action: madmin.ServiceActionRestart, DryRun: r.URL.Query().Get("dry-run") == "true",
+				Results: []madmin.ServiceActionPeerResult{
+					{Host: "online"}, {Host: "offline", Err: "unreachable"}, {Host: "hung", WaitingDrives: map[string]madmin.DiskMetrics{"drive": {}}},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/minio/health/cluster":
+			// Exercise an unhealthy poll before the terminal healthy response.
+			if healthCalls.Add(1) == 1 && unhealthy {
+				w.WriteHeader(http.StatusPreconditionFailed)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL)
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestServiceRestartJSONCompletion(t *testing.T) {
+	for _, wait := range []bool{false, true} {
+		for attempt := 0; attempt < 10; attempt++ {
+			t.Run(fmt.Sprintf("wait=%t/%d", wait, attempt), func(t *testing.T) {
+				server := newServiceRestartTestServer(t, wait)
+				defer server.Close()
+				args := []string{"--json", "admin", "service", "restart", "--dry-run"}
+				if wait {
+					args = append(args, "--wait")
+				}
+				result := runChecksumVerifyCLI(t, server.URL, nil, append(args, "b4")...)
+				if result.exitCode != 0 || len(result.stderr) != 0 {
+					t.Fatalf("exit=%d stdout=%s stderr=%s", result.exitCode, result.stdout, result.stderr)
+				}
+				decoder := json.NewDecoder(bytes.NewReader(result.stdout))
+				var states []int
+				doneCount := 0
+				for {
+					var msg serviceRestartMessage
+					if err := decoder.Decode(&msg); err == io.EOF {
+						break
+					} else if err != nil {
+						t.Fatalf("invalid JSON: %v: %s", err, result.stdout)
+					}
+					if msg.Status != "success" || !msg.Result.DryRun || msg.ServerURL != "b4" || len(msg.Result.Results) != 3 {
+						t.Errorf("changed JSON structure: %s", result.stdout)
+					}
+					states = append(states, msg.State)
+					if msg.State == done {
+						doneCount++
+					}
+				}
+				if doneCount != 1 || len(states) == 0 || states[len(states)-1] != done {
+					t.Fatalf("missing or duplicate final done: states=%v stdout=%s", states, result.stdout)
+				}
+				if wait && (len(states) < 3 || states[0] != restarting || states[1] != waiting) {
+					t.Errorf("missing wait progress: %v", states)
+				}
+				if !wait && len(states) != 1 {
+					t.Errorf("unexpected non-wait progress: %v", states)
+				}
+			})
+		}
 	}
 }

--- a/cmd/admin-service-restart_unix_test.go
+++ b/cmd/admin-service-restart_unix_test.go
@@ -1,0 +1,64 @@
+//go:build darwin || linux
+
+// Copyright (c) 2026 PGSTY
+//
+// This file is part of the Silo object storage client.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestServiceRestartWithoutControllingTTY(t *testing.T) {
+	for _, quiet := range []bool{false, true} {
+		for _, dryRun := range []bool{false, true} {
+			t.Run(fmt.Sprintf("quiet=%t/dry-run=%t", quiet, dryRun), func(t *testing.T) {
+				server := newServiceRestartTestServer(t, true)
+				defer server.Close()
+				args := []string{"admin", "service", "restart", "--wait"}
+				if quiet {
+					args = append([]string{"--quiet"}, args...)
+				}
+				if dryRun {
+					args = append(args, "--dry-run")
+				}
+				command := checksumVerifyCLICommand(t, server.URL, nil, append(args, "b4")...)
+				command.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+				var stdout, stderr bytes.Buffer
+				command.Stdout, command.Stderr = &stdout, &stderr
+				if code := checksumVerifyCLIExitCode(t, command); code != 0 {
+					t.Fatalf("exit=%d stdout=%s stderr=%s", code, &stdout, &stderr)
+				}
+				text := stdout.String()
+				action := "Restart request sent to"
+				if dryRun {
+					action = "Dry run completed for"
+				}
+				if strings.Count(text, "\n") != 1 || !strings.HasPrefix(text, action+" b4") || !strings.Contains(text, "1 online, 1 offline, 1 hung") || !strings.Contains(text, "initialization wait") {
+					t.Errorf("unexpected summary: %q", text)
+				}
+				if strings.Contains(text, "\x1b") || strings.Contains(text, `"status"`) || stderr.Len() != 0 {
+					t.Errorf("unexpected UI/JSON output: stdout=%q stderr=%q", text, stderr.String())
+				}
+			})
+		}
+	}
+}

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -31,7 +31,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -766,7 +765,10 @@ func (c *S3Client) notificationToEventsInfo(ninfo notification.Info) []EventInfo
 			key = record.S3.Object.Key
 		}
 		u := c.targetURL.Clone()
-		u.Path = path.Join(string(u.Separator), bucketName, key)
+		u.Path = string(u.Separator) + bucketName
+		if key != "" {
+			u.Path += string(u.Separator) + key
+		}
 		if strings.HasPrefix(record.EventName, "s3:ObjectCreated:") {
 			if strings.HasPrefix(record.EventName, "s3:ObjectCreated:Copy") {
 				eventsInfo[i] = EventInfo{

--- a/cmd/get-main.go
+++ b/cmd/get-main.go
@@ -125,7 +125,7 @@ func mainGet(cliCtx *cli.Context) (e error) {
 			if getURLs.Error != nil {
 				printGetURLsError(&getURLs)
 				showLastProgressBar(pg, getURLs.Error.ToGoError())
-				return
+				return exitStatus(globalErrorExitStatus)
 			}
 			urls := doCopy(ctx, doCopyOpts{
 				cpURLs:              getURLs,
@@ -134,8 +134,8 @@ func mainGet(cliCtx *cli.Context) (e error) {
 				updateProgressTotal: true,
 			})
 			if urls.Error != nil {
-				e = urls.Error.ToGoError()
-				showLastProgressBar(pg, e)
+				showLastProgressBar(pg, urls.Error.ToGoError())
+				fatalIf(urls.Error.Trace(), "Unable to download.")
 				return
 			}
 		}

--- a/cmd/get-put-exit_test.go
+++ b/cmd/get-put-exit_test.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 PGSTY
+//
+// This file is part of the Silo object storage client.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestGetPutFailureExitStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		code, status := "AccessDenied", http.StatusForbidden
+		if r.URL.Path == "/bucket/missing" {
+			code, status = "NoSuchKey", http.StatusNotFound
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		w.Header().Set("X-Minio-Error-Code", code)
+		w.WriteHeader(status)
+		_, _ = fmt.Fprintf(w, "<Error><Code>%s</Code><Message>%s</Message></Error>", code, code)
+	}))
+	defer server.Close()
+	source := filepath.Join(t.TempDir(), "input")
+	if err := os.WriteFile(source, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, mode := range []string{"default", "quiet", "json"} {
+		for _, tc := range []struct {
+			name      string
+			args      []string
+			errorType string
+		}{
+			{"get local source", []string{"get", source, filepath.Join(t.TempDir(), "out")}, "error"},
+			{"put missing source", []string{"put", source + "-missing", "b4/bucket/object"}, "error"},
+			{"get missing object", []string{"get", "b4/bucket/missing", filepath.Join(t.TempDir(), "out")}, "fatal"},
+			{"get denied transfer", []string{"get", "b4/bucket/denied", filepath.Join(t.TempDir(), "out")}, "fatal"},
+			{"put denied transfer", []string{"put", source, "b4/bucket/denied"}, "fatal"},
+		} {
+			t.Run(mode+"/"+tc.name, func(t *testing.T) {
+				args := append([]string{}, tc.args...)
+				if mode != "default" {
+					args = append([]string{"--" + mode}, args...)
+				}
+				result := runChecksumVerifyCLI(t, server.URL, []string{"MC_REGION=us-east-1"}, args...)
+				if result.exitCode != 1 {
+					t.Errorf("exit = %d, want 1; stdout=%s stderr=%s", result.exitCode, result.stdout, result.stderr)
+				}
+				combined := string(result.stdout) + string(result.stderr)
+				if strings.Contains(combined, "Invalid command usage") {
+					t.Errorf("transfer error reported as command usage: %s", combined)
+				}
+				if mode == "json" {
+					decoder := json.NewDecoder(bytes.NewReader(result.stdout))
+					errors, records := 0, 0
+					var record struct {
+						Status string `json:"status"`
+						Total  *int64 `json:"total"`
+						Error  struct {
+							Type string `json:"type"`
+						} `json:"error"`
+					}
+					for {
+						if err := decoder.Decode(&record); err == io.EOF {
+							break
+						} else if err != nil {
+							t.Fatalf("invalid JSON: %s (%v)", result.stdout, err)
+						}
+						records++
+						if record.Total != nil {
+							t.Errorf("failed transfer emitted success statistics: %s", result.stdout)
+						}
+						if record.Status == "error" {
+							errors++
+						}
+					}
+					// The existing transfer-start record may precede the final error.
+					if errors != 1 || record.Status != "error" || record.Error.Type != tc.errorType || (tc.errorType == "error" && records != 1) {
+						t.Errorf("wrong error contract: %s", result.stdout)
+					}
+					if len(result.stderr) != 0 {
+						t.Errorf("JSON stderr = %s", result.stderr)
+					}
+				} else if len(result.stderr) == 0 {
+					t.Error("missing error diagnostic")
+				}
+			})
+		}
+	}
+}
+
+func TestGetPutSuccessfulTransfers(t *testing.T) {
+	for _, data := range [][]byte{[]byte("ordinary payload\n"), {}} {
+		for _, mode := range []string{"default", "quiet", "json"} {
+			t.Run(fmt.Sprintf("%s/%d bytes", mode, len(data)), func(t *testing.T) {
+				var mu sync.Mutex
+				var uploaded []byte
+				var puts int
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path != "/bucket/object" {
+						t.Errorf("unexpected request %s %s", r.Method, r.URL)
+						http.NotFound(w, r)
+						return
+					}
+					w.Header().Set("Last-Modified", time.Unix(100, 0).UTC().Format(http.TimeFormat))
+					w.Header().Set("ETag", `"test-etag"`)
+					switch r.Method {
+					case http.MethodPut:
+						var reader io.Reader = r.Body
+						if strings.HasPrefix(r.Header.Get("X-Amz-Content-Sha256"), "STREAMING-") {
+							reader = httputil.NewChunkedReader(reader)
+						}
+						body, err := io.ReadAll(reader)
+						if err != nil {
+							t.Error(err)
+						}
+						mu.Lock()
+						uploaded = body
+						puts++
+						mu.Unlock()
+					case http.MethodGet, http.MethodHead:
+						w.Header().Set("Content-Length", fmt.Sprint(len(data)))
+						if r.Method == http.MethodGet {
+							_, _ = w.Write(data)
+						}
+					default:
+						t.Errorf("unexpected request %s %s", r.Method, r.URL)
+						w.WriteHeader(http.StatusMethodNotAllowed)
+					}
+				}))
+				defer server.Close()
+				source, target := filepath.Join(t.TempDir(), "input"), filepath.Join(t.TempDir(), "output")
+				if err := os.WriteFile(source, data, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				for _, args := range [][]string{{"put", source, "b4/bucket/object"}, {"get", "b4/bucket/object", target}} {
+					if mode != "default" {
+						args = append([]string{"--" + mode}, args...)
+					}
+					result := runChecksumVerifyCLI(t, server.URL, []string{"MC_REGION=us-east-1"}, args...)
+					if result.exitCode != 0 {
+						t.Fatalf("exit=%d stdout=%s stderr=%s", result.exitCode, result.stdout, result.stderr)
+					}
+				}
+				got, err := os.ReadFile(target)
+				if err != nil || !bytes.Equal(got, data) {
+					t.Errorf("download = %q, err=%v, want %q", got, err, data)
+				}
+				mu.Lock()
+				defer mu.Unlock()
+				if puts != 1 || !bytes.Equal(uploaded, data) {
+					t.Errorf("PUT count=%d body=%q, want %q", puts, uploaded, data)
+				}
+			})
+		}
+	}
+}

--- a/cmd/mirror-delete_test.go
+++ b/cmd/mirror-delete_test.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2026 PGSTY
+//
+// This file is part of the Silo object storage client.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/minio-go/v7/pkg/encrypt"
+	"github.com/minio/minio-go/v7/pkg/notification"
+)
+
+func TestMirrorDeleteChecksCurrentSource(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		status      int
+		code        string
+		marker      bool
+		cancel      bool
+		clientError bool
+		dryRun      bool
+		wantDeleted bool
+		wantError   bool
+	}{
+		{name: "current version exists", status: http.StatusOK},
+		{name: "object deleted", status: http.StatusNotFound, code: "NoSuchKey", wantDeleted: true},
+		{name: "current delete marker", status: http.StatusNotFound, code: "NoSuchKey", marker: true, wantDeleted: true},
+		{name: "access denied", status: http.StatusForbidden, code: "AccessDenied", wantError: true},
+		{name: "bucket missing", status: http.StatusNotFound, code: "NoSuchBucket", wantError: true},
+		{name: "server failure", status: http.StatusInternalServerError, code: "InternalError", wantError: true},
+		{name: "canceled", cancel: true, wantError: true},
+		{name: "client creation failed", clientError: true, wantError: true},
+		{name: "dry run", status: http.StatusNotFound, code: "NoSuchKey", dryRun: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var heads atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodHead || r.URL.Path != "/bucket/object" {
+					t.Errorf("unexpected source request: %s %s", r.Method, r.URL)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				heads.Add(1)
+				w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+				w.Header().Set("X-Minio-Error-Code", tc.code)
+				if tc.marker {
+					w.Header().Set("X-Amz-Delete-Marker", "true")
+				}
+				w.WriteHeader(tc.status)
+			}))
+			defer server.Close()
+			t.Setenv("MC_HOST_mirrortest", "http://access:secret@"+strings.TrimPrefix(server.URL, "http://"))
+			t.Setenv("MC_REGION", "us-east-1")
+			if tc.clientError {
+				oldNew := S3New
+				S3New = func(*Config) (Client, *probe.Error) {
+					return nil, probe.NewError(errors.New("cannot create source client"))
+				}
+				defer func() { S3New = oldNew }()
+			}
+			target := t.TempDir()
+			file := filepath.Join(target, "object")
+			if err := os.WriteFile(file, []byte("current version"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			defer cancel()
+			if tc.cancel {
+				cancel()
+			}
+			event := EventInfo{
+				Type: notification.ObjectRemovedDelete, Path: server.URL + "/bucket/object",
+			}
+			result := runMirrorDeleteEvent(ctx, t, "mirrortest/bucket", target, event, mirrorOptions{isRemove: true, isFake: tc.dryRun})
+			if tc.status == http.StatusOK {
+				// Redelivery of an old-version deletion must also preserve the target.
+				result = runMirrorDeleteEvent(ctx, t, "mirrortest/bucket", target, event, mirrorOptions{isRemove: true})
+			}
+			if (result.Error != nil) != tc.wantError {
+				t.Errorf("error = %v, want error %v", result.Error, tc.wantError)
+			}
+			if result.SourceContent != nil {
+				t.Fatal("delete result changed into a source-copy result")
+			}
+			data, err := os.ReadFile(file)
+			if tc.wantDeleted {
+				if !os.IsNotExist(err) {
+					t.Fatalf("target still present: data=%q err=%v", data, err)
+				}
+			} else if err != nil || string(data) != "current version" {
+				t.Fatalf("target was changed: data=%q err=%v", data, err)
+			}
+			if !tc.cancel && !tc.clientError && !tc.dryRun && heads.Load() == 0 {
+				t.Error("source was never checked")
+			}
+		})
+	}
+}
+
+func runMirrorDeleteEvent(ctx context.Context, t *testing.T, source, target string, event EventInfo, opts mirrorOptions) URLs {
+	t.Helper()
+	oldLoad := loadMcConfig
+	loadMcConfig = func() (*configV10, *probe.Error) { return &configV10{}, nil }
+	defer func() { loadMcConfig = oldLoad }()
+	results := make(chan URLs, 1)
+	parallel := newParallelManager(results, 1)
+	defer parallel.stopAndWait()
+	status := NewQuietStatus(parallel)
+	defer status.(*QuietStatus).Stat()
+	job := &mirrorJob{sourceURL: source, targetURL: target, opts: opts, parallel: parallel, status: status}
+	job.watchMirrorEvents(ctx, []EventInfo{event})
+	select {
+	case result := <-results:
+		return result
+	case <-time.After(5 * time.Second):
+		t.Fatal("delete task did not finish")
+		return URLs{}
+	}
+}
+
+func TestMirrorDeletePreservesExactKeyAndSSE(t *testing.T) {
+	for _, key := range []string{"prefix/", "object", "dir/space + 中文"} {
+		for _, eventType := range []notification.EventType{notification.ObjectRemovedDelete, notification.ObjectRemovedDeleteMarkerCreated, notification.ILMDelMarkerExpirationDelete} {
+			t.Run(key+"/"+string(eventType), func(t *testing.T) {
+				var heads atomic.Int32
+				server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != http.MethodHead || r.URL.Path != "/bucket/"+key {
+						t.Errorf("unexpected source request: %s %s", r.Method, r.URL)
+						w.WriteHeader(http.StatusBadRequest)
+						return
+					}
+					if r.URL.Query().Has("versionId") {
+						t.Error("checked a historical version")
+					}
+					if r.Header.Get("X-Amz-Server-Side-Encryption-Customer-Key") == "" {
+						t.Error("source HEAD omitted SSE-C")
+					}
+					heads.Add(1)
+					w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+					w.WriteHeader(http.StatusOK)
+				}))
+				defer server.Close()
+				t.Setenv("MC_HOST_mirrortest", "https://access:secret@"+strings.TrimPrefix(server.URL, "https://"))
+				t.Setenv("MC_REGION", "us-east-1")
+				oldInsecure := globalInsecure
+				globalInsecure = true
+				defer func() { globalInsecure = oldInsecure }()
+				sse, err := encrypt.NewSSEC([]byte(strings.Repeat("k", 32)))
+				if err != nil {
+					t.Fatal(err)
+				}
+				// The S3 listen API supplies raw keys. Use the real notification conversion.
+				var info notification.Info
+				raw, err := json.Marshal(map[string]any{"Records": []any{map[string]any{
+					"eventName": eventType, "s3": map[string]any{
+						"bucket": map[string]string{"name": "bucket"}, "object": map[string]string{"key": key},
+					},
+				}}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err = json.Unmarshal(raw, &info); err != nil {
+					t.Fatal(err)
+				}
+				client := &S3Client{targetURL: newClientURL(server.URL)}
+				events := client.notificationToEventsInfo(info)
+				if events[0].Path != server.URL+"/bucket/"+key {
+					t.Fatalf("notification changed key: %q", events[0].Path)
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+				result := runMirrorDeleteEvent(ctx, t, "mirrortest/bucket", t.TempDir(), events[0], mirrorOptions{
+					isRemove: true, encKeyDB: map[string][]prefixSSEPair{"mirrortest": {{Prefix: "mirrortest/bucket/", SSE: sse}}},
+				})
+				if result.Error != nil || heads.Load() != 1 {
+					t.Fatalf("HEAD count=%d error=%v", heads.Load(), result.Error)
+				}
+			})
+		}
+	}
+}
+
+func TestMirrorDeleteFilesystemSource(t *testing.T) {
+	source, target := t.TempDir(), t.TempDir()
+	file := filepath.Join(target, "object")
+	if err := os.WriteFile(file, []byte("deleted source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	result := runMirrorDeleteEvent(context.Background(), t, source, target, EventInfo{
+		Type: notification.ObjectRemovedDelete, Path: filepath.Join(source, "object"),
+	}, mirrorOptions{isRemove: true})
+	if _, err := os.Stat(file); !os.IsNotExist(err) || result.Error != nil {
+		t.Fatalf("filesystem delete failed: stat=%v task=%v", err, result.Error)
+	}
+}
+
+func TestNotificationBucketPathUnchanged(t *testing.T) {
+	var info notification.Info
+	if err := json.NewDecoder(strings.NewReader(`{"Records":[{"eventName":"s3:BucketCreated:*","s3":{"bucket":{"name":"bucket"},"object":{"key":""}}}]}`)).Decode(&info); err != nil {
+		t.Fatal(err)
+	}
+	client := &S3Client{targetURL: newClientURL("http://localhost")}
+	if got := client.notificationToEventsInfo(info)[0].Path; got != "http://localhost/bucket" {
+		t.Fatalf("bucket event path = %q", got)
+	}
+}

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -19,6 +19,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -751,6 +752,26 @@ func (mj *mirrorJob) watchMirrorEvents(ctx context.Context, events []EventInfo) 
 			mirrorURL.TotalSize = mj.status.Get()
 			if mirrorURL.TargetContent != nil && (mj.opts.isRemove || mj.opts.activeActive || mj.opts.isWatch) {
 				mj.parallel.queueTask(func() URLs {
+					if sourceAlias != "" && !mj.opts.isFake {
+						client, err := newClientFromAlias(sourceAlias, sourceURL.String())
+						if err != nil {
+							return mirrorURL.WithError(err)
+						}
+						source, ok := client.(*S3Client)
+						if !ok {
+							return mirrorURL.WithError(probe.NewError(fmt.Errorf("source alias %s is not S3", sourceAlias)))
+						}
+						bucket, object := source.url2BucketAndObject()
+						sse := getSSE(sourceAlias+sourceURL.Path, mj.opts.encKeyDB[sourceAlias])
+						// A deletion event may concern an older version of a still-visible object.
+						_, err = source.getObjectStat(ctx, bucket, object, minio.StatObjectOptions{ServerSideEncryption: sse})
+						if err == nil {
+							return mirrorURL.WithError(nil)
+						}
+						if !errors.As(err.ToGoError(), &ObjectMissing{}) && !errors.As(err.ToGoError(), &ObjectIsDeleteMarker{}) {
+							return mirrorURL.WithError(err)
+						}
+					}
 					return mj.doRemove(ctx, mirrorURL, event)
 				}, 0)
 			}

--- a/cmd/put-main.go
+++ b/cmd/put-main.go
@@ -199,7 +199,7 @@ func mainPut(cliCtx *cli.Context) (e error) {
 			if putURLs.Error != nil {
 				printPutURLsError(&putURLs)
 				showLastProgressBar(pg, putURLs.Error.ToGoError())
-				return
+				return exitStatus(globalErrorExitStatus)
 			}
 			urls := doCopy(ctx, doCopyOpts{
 				cpURLs:           putURLs,


### PR DESCRIPTION
This fixes three inherited CLI defects with local changes to the affected commands:

- Historical-version delete notifications no longer remove a mirror target while the current source object still exists. The watch task checks the exact current object, preserves targets on uncertain errors, and retains literal notification keys. Addresses [minio/mc #5139](https://github.com/minio/mc/issues/5139).
- `get` and `put` preparation failures now exit 1 while preserving their existing diagnostics. Download transfer failures report the actual error instead of “Invalid command usage.” Addresses [minio/mc #5250](https://github.com/minio/mc/issues/5250).
- Restart commands use TUI only with terminal stdin/stdout/stderr. Other modes have one message consumer: JSON reliably delivers its final `done`, and text emits one final summary. A separate safety commit prevents failed dry runs from falling back to a real restart. Addresses [minio/mc #5272](https://github.com/minio/mc/issues/5272).

Validation: baseline failures reproduced with regression tests; complete `go test -race -tags kqueue ./...`, golangci-lint, `make vet`, dependency/branding/credits/release-state checks, and Windows test compilation passed. The complete existing functional suite and additional versioned-mirror, get/put, no-TTY, PTY, redirection and interruption tests passed against SILO `a3df317ae0725eb650e4d3e21551154f69be6229`, built locally from source. All test servers were disposable local processes. Fable 5.1 max reviewed each repair independently.

The changes add no dependencies, CLI flags, version scans, or synchronization framework. Historical-version content rollback and cross-system HEAD/DELETE atomicity remain outside the mirror fix. This PR does not create an MC tag or release.
