### PR TITLE
docs: align release notes and current component status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+## RELEASE.2026-09-13T00-00-00Z — 2026-09-13
+
+Package version: `20260913000000.0.0`. Source:
+`4f609a4da3bb8548446715867b68ab6c2d53a097`; Go module version:
+`v0.0.0-20260913012246-4f609a4da3bb`.
+[GitHub release](https://github.com/pgsty/mc/releases/tag/RELEASE.2026-09-13T00-00-00Z) ·
+[Changes since 20260903](https://github.com/pgsty/mc/compare/RELEASE.2026-09-03T07-13-05Z...RELEASE.2026-09-13T00-00-00Z)
+
+- Preserve historical destination versions in `mirror --remove --watch`.
+- Make service-restart dry runs report the plan without executing it, and make
+  noninteractive restart behavior explicit.
+- Return failure for failed transfers and S3 Select errors. Honor an explicit
+  checksum on empty uploads and keep `pipe` JSON output under `--quiet`.
+- Accept on/off boolean environment values and repair cross-platform CLI/JSON
+  behavior. Existing configuration paths and `MC_*` names remain supported.
+- Use silo-pkg v3.14.0 directly and upstream minio-go
+  `v7.3.1-0.20260910142817-60bd07042d49`. Preserve the policy Deny/NotResource
+  and bounded wildcard fixes introduced in pkg v3.13.3. Already-lost policy
+  clauses must be recovered from the original policy source.
+- Refresh Go x/* modules and the UBI image; build with Go 1.27.1 and scan with
+  govulncheck 1.8.0. Retain go-systemd v22.6.0 for NetBSD portability. The scan
+  reports no reachable or imported vulnerable package; an unused OpenPGP
+  module-only advisory remains.
+
+**Password-policy migration:** pkg v3.14.0 separates ChangeMyPassword from
+CreateUser. Keep both actions in the same Deny statement if the previous
+combined restriction must survive an upgrade or rollback. Saved policies are
+not rewritten. This client release alone does not change a Server's permission
+mapping. As of 2026-09-13, matching Server/Console source is merged but not yet
+released; the latest Server 20260903 and Console v2.4.0 still use the old mapping.
+See the [migration guide](https://silo.pgsty.com/compatibility/password-permissions/)
+and [component matrix](https://silo.pgsty.com/compatibility/versions/).
+
+The immutable release has six Linux/macOS/Windows archives, RPM/DEB/APK packages
+for both architectures, and checksums (19 assets). Archives and the checksum
+manifest have verified build attestations; RPMs carry the PGSTY GPG signature.
+The release and `latest` Docker tags resolve to the verified amd64/arm64 manifest
+`sha256:aa5cc1401b3e1ab482d215d5717e9e69b4f14970a3656f330ed20a549fe19020`.
+
+Earlier releases: [release archive](https://github.com/pgsty/mc/releases).

--- a/README.md
+++ b/README.md
@@ -32,11 +32,19 @@
 > [!IMPORTANT]
 > `pgsty/mc` is an independent, community-maintained fork of the open-source [MinIO Client](https://github.com/minio/mc), published by [Pigsty](https://pigsty.io). It is not affiliated with, endorsed by, or sponsored by MinIO, Inc. “MinIO” is used only to identify the upstream project and compatibility lineage.
 
+## Current release
+
+[20260913](https://github.com/pgsty/mc/releases/tag/RELEASE.2026-09-13T00-00-00Z)
+(`20260913000000.0.0`) uses silo-pkg v3.14.0 and upstream minio-go `60bd07042d49`.
+See [CHANGELOG.md](CHANGELOG.md) for behavior changes and the
+[component matrix](https://silo.pgsty.com/compatibility/versions/) for the
+published Server/Console versions versus their newer main branches.
+
 ## Overview
 
 `pgsty/mc` maintains one downstream release line based on the final upstream MinIO Client commit, [`77f82e18`](https://github.com/minio/mc/commit/77f82e18b5401a65958f1619df6ebb994634bd88). After the upstream repository was archived, this fork keeps the client built, patched, tested, and released through the same maintained supply chain as the [Silo](https://silo.pgsty.com/) object storage server, while remaining a general-purpose client for filesystems and Amazon S3-compatible object stores.
 
-The fork follows one rule: **the shipped artifact and its distribution channels are renamed; the tool you use is not.** Standalone archives and Linux packages ship the binary as `mcli`, while commands, flags, configuration, and wire behavior stay unchanged from upstream. The complete, versioned list of differences is maintained in the [compatibility notes](https://silo.pgsty.com/compatibility/mcli/).
+The fork follows one rule: **the shipped artifact and its distribution channels are renamed; the tool you use is not.** Standalone archives and Linux packages ship the binary as `mcli`, while retaining familiar command syntax, configuration and wire interfaces, with the documented correctness and security changes below. The complete, versioned list of differences is maintained in the [compatibility notes](https://silo.pgsty.com/compatibility/mcli/).
 
 The official project portal is [silo.pgsty.com](https://silo.pgsty.com/). It brings the command reference, downloads, release and security notes, and project legal information together.
 
@@ -87,7 +95,7 @@ Changes are kept narrow and tested where practical. Maintenance is best effort; 
 
 ## Governance
 
-The client is maintained together with the [Silo server](https://github.com/pgsty/silo) under one release process: DCO-signed commits, pull requests gated by required CI checks (a solo-maintained project: there is no independent human reviewer to enforce), signed and immutable `RELEASE.YYYY-MM-DDTHH-MM-SSZ` tags with checksummed artifacts. Each release is announced with a [release note](https://silo.pgsty.com/tags/mcli/) on the portal; security advisories follow the [security policy](https://silo.pgsty.com/about/security/). Upstream copyright, license, and third-party notices are preserved in [`LICENSE`](LICENSE), [`NOTICE`](NOTICE), and [`CREDITS`](CREDITS).
+The client is maintained together with the [Silo server](https://github.com/pgsty/silo) under one release process: DCO-signed commits, reviewed changes with CI validation (direct pushes to main are permitted; artifact publication separately requires successful workflows for the exact tagged commit), signed and immutable `RELEASE.YYYY-MM-DDTHH-MM-SSZ` tags with checksummed artifacts. Each release is announced with a [release note](https://silo.pgsty.com/tags/mcli/) on the portal; security advisories follow the [security policy](https://silo.pgsty.com/about/security/). Upstream copyright, license, and third-party notices are preserved in [`LICENSE`](LICENSE), [`NOTICE`](NOTICE), and [`CREDITS`](CREDITS).
 
 ## Compatibility
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -32,11 +32,18 @@
 > [!IMPORTANT]
 > `pgsty/mc` 是由 [Pigsty](https://pigsty.cc) 独立维护、从开源 [MinIO Client](https://github.com/minio/mc) 延续而来的社区分支。本项目与 MinIO, Inc. 不存在隶属、背书或赞助关系；文中使用 “MinIO” 仅用于说明上游项目及兼容谱系。
 
+## 当前版本
+
+[20260913](https://github.com/pgsty/mc/releases/tag/RELEASE.2026-09-13T00-00-00Z)
+（`20260913000000.0.0`）使用 silo-pkg v3.14.0 与上游 minio-go `60bd07042d49`。
+行为变化见 [CHANGELOG.md](CHANGELOG.md) 和[中文发布说明](https://silo.pgsty.com/zh/blog/release/mcli-20260913/)。
+[组件版本矩阵](https://silo.pgsty.com/zh/compatibility/versions/) 区分 Server/Console 已发布版本与更新后的主分支。
+
 ## 概述
 
 `pgsty/mc` 维护一条基于上游 MinIO Client 最后一个提交 [`77f82e18`](https://github.com/minio/mc/commit/77f82e18b5401a65958f1619df6ebb994634bd88) 的下游版本线。在上游仓库归档后，本分支让客户端与 [Silo](https://silo.pgsty.com/zh/) 对象存储服务器共用同一条受维护的供应链完成构建、修补、测试和发布，同时仍是面向文件系统与 Amazon S3 兼容对象存储的通用客户端。
 
-本分支遵循一条原则：**改名的是发行产物与分发渠道，不是你使用的工具。** 独立归档包与 Linux 软件包以 `mcli` 命名，而命令、参数、配置与协议行为与上游保持一致。完整的差异清单随版本更新，见[兼容性说明](https://silo.pgsty.com/zh/compatibility/mcli/)。
+本分支遵循一条原则：**改名的是发行产物与分发渠道，不是你使用的工具。** 独立归档包与 Linux 软件包以 `mcli` 命名，并保留熟悉的命令语法、配置与协议接口；正确性与安全修复引入的行为差异另行说明。完整的差异清单随版本更新，见[兼容性说明](https://silo.pgsty.com/zh/compatibility/mcli/)。
 
 项目统一门户为 [silo.pgsty.com](https://silo.pgsty.com/zh/)，集中提供命令参考、下载安装、版本与安全动态，以及项目法律信息。
 
@@ -87,7 +94,7 @@
 
 ## 治理
 
-本客户端与 [Silo 服务器](https://github.com/pgsty/silo)在同一套发布流程下共同维护：提交必须签署 DCO、Pull Request 必须通过全部必需 CI 检查（本项目由单人维护，不存在可强制执行的独立人工评审）、以签名且不可变的 `RELEASE.YYYY-MM-DDTHH-MM-SSZ` 标签发布带校验和的产物。每个版本都会在门户发布[版本说明](https://silo.pgsty.com/zh/tags/mcli/)；安全问题遵循[安全策略](https://silo.pgsty.com/zh/about/security/)处理。上游版权、许可证与第三方声明完整保留于 [`LICENSE`](LICENSE)、[`NOTICE`](NOTICE) 与 [`CREDITS`](CREDITS)。
+客户端与 [Silo 服务端](https://github.com/pgsty/silo) 共同维护。提交要求 DCO 签署并经过 CI 验证；允许直接推送 main，制品发布另行要求精确标签提交的工作流通过。`RELEASE.YYYY-MM-DDTHH-MM-SSZ` 标签由管理员创建且不可变。发布与安全说明见[项目门户](https://silo.pgsty.com/zh/blog/release/)，上游版权及第三方声明保留。
 
 ## 兼容策略
 


### PR DESCRIPTION
Document the published 20260913 client, its exact module version, dependency pins, behavior changes and verified artifacts. Distinguish the new client from unreleased Server/Console password handling, and align the governance description with the current tag-only rulesets.

Validation: public release metadata and source pins checked; documentation-only diff check passed.
